### PR TITLE
Add Telegram client notifications

### DIFF
--- a/src/app/api/admin/tg/set-webhook/route.ts
+++ b/src/app/api/admin/tg/set-webhook/route.ts
@@ -1,0 +1,18 @@
+export const runtime = "edge";
+
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token") || "";
+  if (token !== (process.env.ADMIN_TOKEN || "")) {
+    return NextResponse.json({ ok:false, error:"forbidden" }, { status: 403 });
+  }
+  const BOT = process.env.TELEGRAM_BOT_TOKEN || "";
+  if (!BOT) return NextResponse.json({ ok:false, error:"no_bot" }, { status: 500 });
+
+  const webhook = `${url.origin}/api/tg/webhook`;
+  const r = await fetch(`https://api.telegram.org/bot${BOT}/setWebhook?url=${encodeURIComponent(webhook)}`);
+  const j = await r.json().catch(()=>({ ok:false }));
+  return NextResponse.json(j);
+}

--- a/src/app/api/tg/deeplink/route.ts
+++ b/src/app/api/tg/deeplink/route.ts
@@ -1,0 +1,40 @@
+export const runtime = "edge";
+
+import { NextRequest, NextResponse } from "next/server";
+import { first, run } from "@/app/lib/db";
+import { headers } from "next/headers";
+
+function baseUrl() {
+  const h = headers();
+  return (
+    process.env.PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `${h.get("x-forwarded-proto") || "https"}://${h.get("host")}`
+  );
+}
+
+function makeToken() {
+  // короткий токен для start-параметра
+  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const order = (url.searchParams.get("o") || "").trim();
+  if (!order) return NextResponse.json({ ok:false, error:"order_required" }, { status: 400 });
+
+  // если уже есть токен — переиспользуем
+  let row = await first("SELECT token FROM tg_tokens WHERE order_number=?", order);
+  if (!row) {
+    const token = makeToken();
+    await run("INSERT INTO tg_tokens (token, order_number) VALUES (?,?)", token, order);
+    row = { token };
+  }
+
+  const bot = (process.env.TELEGRAM_CLIENT_BOT || "").replace(/^@/, "");
+  if (!bot) return NextResponse.json({ ok:false, error:"bot_not_configured" }, { status: 500 });
+
+  const deep = `https://t.me/${bot}?start=${encodeURIComponent(`ord_${order}_${row.token}`)}`;
+  return NextResponse.json({ ok:true, url: deep, web: baseUrl() });
+}
+

--- a/src/app/api/tg/webhook/route.ts
+++ b/src/app/api/tg/webhook/route.ts
@@ -1,0 +1,61 @@
+export const runtime = "edge";
+
+import { NextRequest, NextResponse } from "next/server";
+import { first, run } from "@/app/lib/db";
+
+// отправка сообщения клиенту
+async function tgSend(chatId: string | number, text: string) {
+  const BOT = process.env.TELEGRAM_BOT_TOKEN || "";
+  if (!BOT) return;
+  await fetch(`https://api.telegram.org/bot${BOT}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML", disable_web_page_preview: true })
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const raw = await req.text();
+  let update: any = null;
+  try { update = JSON.parse(raw); } catch { return NextResponse.json({ ok:true }); }
+
+  const msg = update?.message || update?.edited_message || null;
+  const chatId = msg?.chat?.id ? String(msg.chat.id) : null;
+  const text = (msg?.text || "").trim();
+
+  if (!chatId) return NextResponse.json({ ok:true });
+
+  // /start ord_<orderNumber>_<token>
+  if (text.startsWith("/start")) {
+    const payload = text.replace("/start", "").trim();
+    const m = payload.match(/^ord_(.+)_(.+)$/);
+    if (m) {
+      const orderNumber = m[1];
+      const token = m[2];
+
+      const row = await first("SELECT order_number FROM tg_tokens WHERE token=? AND order_number=?", token, orderNumber);
+      if (row) {
+        await run("UPDATE orders SET customer_tg_chat_id=? WHERE number=?", chatId, orderNumber);
+        await tgSend(chatId, [
+          `🔔 <b>DH22</b>`,
+          `Подписка на уведомления по заказу <b>${orderNumber}</b> оформлена.`,
+          `Мы сообщим об оплате, передаче в доставку и получении.`
+        ].join("\n"));
+        return NextResponse.json({ ok:true });
+      }
+    }
+    // нет валидного payload — просто приветствие
+    await tgSend(chatId, `Привет! Это бот DH22. Оформите заказ на сайте и нажмите «Подписаться в Telegram» на странице «Спасибо».`);
+    return NextResponse.json({ ok:true });
+  }
+
+  // /stop — отписка: обнулим у всех заказов с этим chat_id
+  if (text === "/stop") {
+    await run("UPDATE orders SET customer_tg_chat_id=NULL WHERE customer_tg_chat_id=?", chatId);
+    await tgSend(chatId, `Вы отписались от уведомлений DH22.`);
+    return NextResponse.json({ ok:true });
+  }
+
+  return NextResponse.json({ ok:true });
+}
+

--- a/src/app/checkout/success/page.jsx
+++ b/src/app/checkout/success/page.jsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 export default function SuccessPage({ searchParams }) {
   const number = searchParams?.o || searchParams?.order || "";
   const [state, setState] = useState({ status: "loading", paid: false, method: "online" });
+  const [tg, setTg] = useState({ url: "", ready: false });
 
   useEffect(() => {
     // очистить корзину один раз
@@ -31,6 +32,17 @@ export default function SuccessPage({ searchParams }) {
     return () => clearTimeout(t);
   }, [number]);
 
+  useEffect(() => {
+    (async () => {
+      if (!number) return;
+      try {
+        const r = await fetch(`/api/tg/deeplink?o=${encodeURIComponent(number)}`, { cache: "no-store" });
+        const j = await r.json();
+        if (j?.ok && j.url) setTg({ url: j.url, ready: true });
+      } catch {}
+    })();
+  }, [number]);
+
   return (
     <div className="container mx-auto px-4 py-16">
       <h1 className="text-2xl mb-2">Спасибо за заказ!</h1>
@@ -46,6 +58,16 @@ export default function SuccessPage({ searchParams }) {
           <div>Ожидаем подтверждение оплаты… Статус: <b>{state.status}</b></div>
         )}
       </div>
+      {tg.ready && (
+        <div className="mt-6">
+          <a href={tg.url} target="_blank" className="inline-block px-4 py-2 border">
+            Получать апдейты в Telegram
+          </a>
+          <div className="text-sm opacity-70 mt-1">
+            Нажмите, откройте бота и подтвердите подписку — мы пришлём уведомления по этому заказу.
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/lib/notify.ts
+++ b/src/app/lib/notify.ts
@@ -142,6 +142,11 @@ export async function notifyOrderCreated(order: any, items: any[]) {
     `Клиент: ${order.customer_name || "—"} • ${order.customer_phone || "—"} • ${order.customer_email || "—"}`
   ].join("\n");
   await notifyTelegram(text);
+  await notifyClientTelegram(order, [
+    `🧾 Заказ <b>${order.number}</b> создан`,
+    `Сумма: ${rub(order.amount_total)}`,
+    `Доставка: ${order.delivery_method || "—"} ${order.delivery_pvz_name ? "• " + order.delivery_pvz_name : ""} ${order.delivery_address ? "• " + order.delivery_address : ""}`
+  ]);
 }
 
 export async function notifyOrderPaid(order: any, items: any[]) {
@@ -162,5 +167,22 @@ export async function notifyOrderPaid(order: any, items: any[]) {
     `Клиент: ${order.customer_name || "—"} • ${order.customer_phone || "—"}`
   ].join("\n");
   await notifyTelegram(text);
+  await notifyClientTelegram(order, [
+    `✅ Оплата получена по заказу <b>${order.number}</b>`,
+    `Мы начали сборку и скоро передадим в доставку.`
+  ]);
+}
+
+export async function notifyClientTelegram(order: any, textLines: string[]) {
+  const chat = (order?.customer_tg_chat_id || "").trim();
+  if (!chat) return;
+  const BOT = process.env.TELEGRAM_BOT_TOKEN || "";
+  if (!BOT) return;
+  const text = textLines.join("\n");
+  await fetch(`https://api.telegram.org/bot${BOT}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chat, text, parse_mode: "HTML", disable_web_page_preview: true })
+  });
 }
 


### PR DESCRIPTION
## Summary
- add API for Telegram deeplink token generation
- bind Telegram chats via webhook and provide admin webhook setter
- expose Telegram subscription link on order success page and notify clients on status changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3f0ca90c83288cf8acb2be1439a6