### PR TITLE
Limit product listings to 20 items

### DIFF
--- a/src/app/accessories/page.jsx
+++ b/src/app/accessories/page.jsx
@@ -5,7 +5,7 @@ export const runtime = "edge";
 
 export default async function Accessories() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Аксессуары' AND active=1 AND quantity>0 ORDER BY id DESC"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Аксессуары' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">

--- a/src/app/new/page.jsx
+++ b/src/app/new/page.jsx
@@ -5,7 +5,7 @@ export const runtime = "edge";
 
 export default async function NewArrivals() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">

--- a/src/app/women/page.jsx
+++ b/src/app/women/page.jsx
@@ -5,7 +5,7 @@ export const runtime = "edge";
 
 export default async function Women() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Женская одежда' AND active=1 AND quantity>0 ORDER BY id DESC"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Женская одежда' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">


### PR DESCRIPTION
## Summary
- restrict accessories listing to 20 active products with stock
- cap new arrivals listing at 20 in-stock items
- limit women's category listing to 20 active, available products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b794d06108328a3206f6c0488303b