### PR TITLE
fix: remove edge runtime from admin product pages

### DIFF
--- a/src/app/admin/products/[id]/page.jsx
+++ b/src/app/admin/products/[id]/page.jsx
@@ -1,5 +1,4 @@
 "use client";
-export const runtime = "edge";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import ProductForm from "../_Form";

--- a/src/app/admin/products/_Form.jsx
+++ b/src/app/admin/products/_Form.jsx
@@ -1,5 +1,4 @@
 "use client";
-export const runtime = "edge";
 import { useRef, useState } from "react";
 import { withToken } from "../_lib";
 

--- a/src/app/admin/products/new/page.jsx
+++ b/src/app/admin/products/new/page.jsx
@@ -1,5 +1,4 @@
 "use client";
-export const runtime = "edge";
 import { useRouter } from "next/navigation";
 import ProductForm from "../_Form";
 

--- a/src/app/admin/products/page.jsx
+++ b/src/app/admin/products/page.jsx
@@ -1,5 +1,4 @@
 "use client";
-export const runtime = "edge";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { withToken } from "../_lib";


### PR DESCRIPTION
## Summary
- remove edge runtime export from admin products pages and form

## Testing
- `npm run build`
- `npm start` (background) & `curl -I http://localhost:3000/admin/products`
- `curl -I http://localhost:3000/admin/products/new`
- `curl -I http://localhost:3000/admin/products/1`


------
https://chatgpt.com/codex/tasks/task_e_689c4c2a64ac832891d1beaec136853c