### PR TITLE
Ensure main_image fallback for product images

### DIFF
--- a/src/app/accessories/page.jsx
+++ b/src/app/accessories/page.jsx
@@ -5,16 +5,18 @@ export const runtime = "edge";
 
 export default async function Accessories() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(NULLIF(main_image,'/i'),image_url) AS image_url FROM products WHERE category='Аксессуары' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Аксессуары' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">
       <h1 className="text-2xl mb-6">Аксессуары</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {items.map((p) => {
-          const img = p.image_url?.startsWith("/i/") || p.image_url?.startsWith("http")
-            ? p.image_url
-            : "/placeholder.png";
+          const img =
+            (p.image_url || p.main_image || "").startsWith("/i/") ||
+            (p.image_url || p.main_image || "").startsWith("http")
+              ? p.image_url || p.main_image
+              : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
               <img src={img} alt={p.name} className="w-full aspect-[3/4] object-cover border" />

--- a/src/app/admin/products/page.jsx
+++ b/src/app/admin/products/page.jsx
@@ -32,9 +32,11 @@ export default function AdminProductsList({ searchParams }) {
       </div>
       <div className="divide-y">
         {items.map((p) => {
-          const img = p.main_image?.startsWith("/i/") || p.main_image?.startsWith("http")
-            ? p.main_image
-            : "/placeholder.png";
+          const img =
+            (p.image_url || p.main_image || "").startsWith("/i/") ||
+            (p.image_url || p.main_image || "").startsWith("http")
+              ? p.image_url || p.main_image
+              : "/placeholder.png";
           return (
             <div key={p.id} className="py-3 flex items-center gap-4">
               <img src={img} alt="" className="w-12 h-12 object-cover border" />

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -12,7 +12,7 @@ async function loadOne(idOrSlug: string) {
   const row: any = isNum
     ? await first("SELECT * FROM products WHERE id=?", idOrSlug)
     : await first("SELECT * FROM products WHERE slug=?", idOrSlug);
-  if (row) row.main_image = (row.main_image && row.main_image !== "/i") ? row.main_image : (row.image_url || "");
+  if (row) row.main_image = row.main_image || row.image_url || "";
   return row;
 }
 
@@ -51,9 +51,12 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   if (b.active != null) set("active", b.active ? 1 : 0);
   if (b.quantity != null) set("quantity", Math.max(0, parseInt(b.quantity)));
   if (typeof b.description === "string") set("description", b.description);
-  if (typeof b.main_image === "string") {
-    let m = b.main_image.trim();
-    set("main_image", m && m !== "/i" ? m : null);
+  if (typeof b.main_image === "string" || typeof b.image_url === "string") {
+    let m = (b.main_image || b.image_url || "").trim();
+    m = m && m !== "/i" ? m : null;
+    set("main_image", m);
+    fields.push("image_url=COALESCE(?, image_url)");
+    vals.push(m);
   }
   if (b.sizes) set("sizes", JSON.stringify(b.sizes));
   if (b.colors) set("colors", JSON.stringify(b.colors));

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
 
   const rows = await all(
     `SELECT id,slug,name,price,category,active,quantity,
-            COALESCE(NULLIF(main_image,'/i'),image_url) AS main_image
+            COALESCE(main_image,image_url) AS main_image
        FROM products
        ${where.length ? "WHERE " + where.join(" AND ") : ""}
        ORDER BY id DESC
@@ -57,15 +57,15 @@ export async function POST(req: NextRequest) {
   const quantity = Math.max(0, parseInt(b.quantity || 0));
   const category = (b.category || "").trim();
   const description = b.description || "";
-  let main_image = (b.main_image || "").trim();
+  let main_image = (b.main_image || b.image_url || "").trim();
   if (!main_image || main_image === "/i") main_image = null;
   const sizes = JSON.stringify(b.sizes || []);
   const colors = JSON.stringify(b.colors || []);
   const gallery = JSON.stringify(b.gallery || []);
 
   await run(
-    `INSERT INTO products (slug,name,price,category,active,quantity,description,main_image,sizes,colors,gallery,updated_at)
-     VALUES (?,?,?,?,?,?,?,?,?,?,?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
+    `INSERT INTO products (slug,name,price,category,active,quantity,description,main_image,image_url,sizes,colors,gallery,updated_at)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,strftime('%Y-%m-%dT%H:%M:%fZ','now'))`,
     slug,
     name,
     price,
@@ -73,6 +73,7 @@ export async function POST(req: NextRequest) {
     active,
     quantity,
     description,
+    main_image,
     main_image,
     sizes,
     colors,

--- a/src/app/new/page.jsx
+++ b/src/app/new/page.jsx
@@ -5,16 +5,18 @@ export const runtime = "edge";
 
 export default async function NewArrivals() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(NULLIF(main_image,'/i'),image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">
       <h1 className="text-2xl mb-6">Новинки</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {items.map((p) => {
-          const img = p.image_url?.startsWith("/i/") || p.image_url?.startsWith("http")
-            ? p.image_url
-            : "/placeholder.png";
+          const img =
+            (p.image_url || p.main_image || "").startsWith("/i/") ||
+            (p.image_url || p.main_image || "").startsWith("http")
+              ? p.image_url || p.main_image
+              : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
               <img src={img} alt={p.name} className="w-full aspect-[3/4] object-cover border" />

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -5,7 +5,7 @@ export const runtime = "edge";
 
 export default async function Home() {
   const products = await all(
-    "SELECT id,slug,name,price,COALESCE(NULLIF(main_image,'/i'),image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC LIMIT 8"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE active=1 AND quantity>0 ORDER BY id DESC LIMIT 8"
   );
   return (
     <section className="container mx-auto px-4 py-10">
@@ -15,9 +15,11 @@ export default async function Home() {
       </div>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {products.map((p) => {
-          const img = p.image_url?.startsWith("/i/") || p.image_url?.startsWith("http")
-            ? p.image_url
-            : "/placeholder.png";
+          const img =
+            (p.image_url || p.main_image || "").startsWith("/i/") ||
+            (p.image_url || p.main_image || "").startsWith("http")
+              ? p.image_url || p.main_image
+              : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
               <img src={img} alt={p.name} className="w-full aspect-[3/4] object-cover border" />

--- a/src/app/product/[slug]/page.jsx
+++ b/src/app/product/[slug]/page.jsx
@@ -5,7 +5,7 @@ export const runtime = "edge";
 
 export default async function ProductPage({ params }) {
   const p = await first(
-    "SELECT slug,name,price,description,quantity,COALESCE(NULLIF(main_image,'/i'),image_url) AS main_image,sizes,colors,gallery FROM products WHERE slug=? AND active=1 AND quantity>0",
+    "SELECT slug,name,price,description,quantity,COALESCE(main_image,image_url) AS main_image,sizes,colors,gallery FROM products WHERE slug=? AND active=1 AND quantity>0",
     params.slug
   );
   if (!p) return <div className="container mx-auto px-4 py-10">Товар не найден</div>;

--- a/src/app/women/page.jsx
+++ b/src/app/women/page.jsx
@@ -5,16 +5,18 @@ export const runtime = "edge";
 
 export default async function Women() {
   const items = await all(
-    "SELECT id,slug,name,price,COALESCE(NULLIF(main_image,'/i'),image_url) AS image_url FROM products WHERE category='Женская одежда' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
+    "SELECT id,slug,name,price,COALESCE(main_image,image_url) AS image_url FROM products WHERE category='Женская одежда' AND active=1 AND quantity>0 ORDER BY id DESC LIMIT 20"
   );
   return (
     <div className="container mx-auto px-4 py-10">
       <h1 className="text-2xl mb-6">Женская одежда</h1>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {items.map((p) => {
-          const img = p.image_url?.startsWith("/i/") || p.image_url?.startsWith("http")
-            ? p.image_url
-            : "/placeholder.png";
+          const img =
+            (p.image_url || p.main_image || "").startsWith("/i/") ||
+            (p.image_url || p.main_image || "").startsWith("http")
+              ? p.image_url || p.main_image
+              : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
               <img src={img} alt={p.name} className="w-full aspect-[3/4] object-cover border" />


### PR DESCRIPTION
## Summary
- use `COALESCE(main_image, image_url)` in product queries
- load card images from `image_url` or `main_image` with a placeholder fallback
- update admin product endpoints to write `main_image` and duplicate `image_url`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(interrupted: build log stops while creating optimized production build)*

------
https://chatgpt.com/codex/tasks/task_e_689c5bdd8744832888ee8b076c55fded