### PR TITLE
feat: add catalog link to admin header

### DIFF
--- a/src/app/admin/AdminHeader.jsx
+++ b/src/app/admin/AdminHeader.jsx
@@ -1,0 +1,12 @@
+'use client';
+import Link from "next/link";
+
+export default function AdminHeader({ token }) {
+  const t = encodeURIComponent(token);
+  return (
+    <nav className="flex gap-4 border-b py-3 mb-6">
+      <Link href={`/admin?t=${t}`}>Заказы</Link>
+      <Link href={`/admin/products?t=${t}`}>Каталог</Link>
+    </nav>
+  );
+}

--- a/src/app/admin/layout.jsx
+++ b/src/app/admin/layout.jsx
@@ -1,0 +1,14 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import AdminHeader from './AdminHeader';
+
+export default function AdminLayout({ children }) {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('t') || '';
+  return (
+    <>
+      <AdminHeader token={token} />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable AdminHeader with links to orders and catalog
- introduce admin layout passing auth token to header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5fa40d5c832884f5349fbd6ced22