### PR TITLE
Fix admin product catalog API and form handling

### DIFF
--- a/src/app/admin/products/page.jsx
+++ b/src/app/admin/products/page.jsx
@@ -2,18 +2,14 @@
 export const runtime = 'edge';
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { withToken } from "../_lib";
 
 export default function AdminProductsList({ searchParams }) {
-  const token = searchParams?.t || "";
+  const t = searchParams?.t || "";
   const [q, setQ] = useState(searchParams?.q || "");
   const [items, setItems] = useState([]);
 
   async function load() {
-    const u = new URL("/api/admin/products", window.location.origin);
-    u.searchParams.set("token", token);
-    if (q) u.searchParams.set("q", q);
-    const r = await fetch(u, { cache: "no-store" });
+    const r = await fetch(`/api/admin/products?token=${encodeURIComponent(t)}&q=${encodeURIComponent(q)}`, { cache: "no-store" });
     const j = await r.json();
     setItems(j?.items || []);
   }
@@ -28,7 +24,7 @@ export default function AdminProductsList({ searchParams }) {
       <div className="flex gap-2">
         <input className="border px-2 py-1" placeholder="поиск…" value={q} onChange={(e) => setQ(e.target.value)} />
         <button className="border px-3" onClick={load}>Искать</button>
-        <Link className="border px-3" href={`/admin/products/new?t=${encodeURIComponent(token)}`}>+ Новый</Link>
+        <Link className="border px-3" href={`/admin/products/new?t=${encodeURIComponent(t)}`}>+ Новый</Link>
       </div>
       <div className="divide-y">
         {items.map((p) => {
@@ -44,7 +40,7 @@ export default function AdminProductsList({ searchParams }) {
                 <div className="font-medium">{p.name}</div>
                 <div className="text-sm opacity-70">{p.slug} • {p.category || "—"} • {p.active ? "активен" : "скрыт"} • остаток {p.quantity}</div>
               </div>
-              <Link className="border px-3 py-1" href={`/admin/products/${p.id}?t=${encodeURIComponent(token)}`}>Править</Link>
+              <Link className="border px-3 py-1" href={`/admin/products/${p.id}?t=${encodeURIComponent(t)}`}>Править</Link>
             </div>
           );
         })}

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -3,47 +3,42 @@ export const runtime = "edge";
 import { NextRequest, NextResponse } from "next/server";
 import { first, run } from "@/app/lib/db";
 
-function ok(data: any = {}) {
-  return NextResponse.json({ ok: true, ...data }, { status: 200 });
-}
-function fail(error: string, detail?: any, status = 200) {
-  return NextResponse.json({ ok: false, error, detail }, { status });
-}
+const getToken = (url: string) => {
+  const u = new URL(url);
+  return u.searchParams.get("token") || u.searchParams.get("t") || "";
+};
+const ok = (x: any = {}) => NextResponse.json({ ok: true, ...x }, { status: 200 });
+const fail = (error: string, detail?: any) =>
+  NextResponse.json({ ok: false, error, detail }, { status: 200 });
 
-function parseArr(x: any) {
-  if (!x) return [];
-  if (Array.isArray(x)) return x;
-  try { return JSON.parse(String(x)); } catch { return []; }
-}
-function int(v: any, d = 0) {
-  const n = Number(v);
-  return Number.isFinite(n) ? Math.trunc(n) : d;
-}
-function bool(v: any) {
-  if (typeof v === "boolean") return v;
-  return v === "1" || v === 1 || String(v).toLowerCase() === "true";
-}
-const normSlug = (s: string) =>
+const toInt = (v: any, d = 0) => (Number.isFinite(Number(v)) ? Math.trunc(Number(v)) : d);
+const toBool = (v: any) =>
+  typeof v === "boolean" ? v : v === 1 || v === "1" || String(v).toLowerCase() === "true";
+const toArr = (v: any) => {
+  if (!v) return [];
+  if (Array.isArray(v)) return v;
+  try { return JSON.parse(String(v)); } catch { return []; }
+};
+const slugify = (s: string) =>
   (s || "")
     .toLowerCase()
-    .replace(/[^a-z0-9\u0400-\u04FF-]+/gi, "-")
+    .replace(/[^a-z0-9\u0400-\u04ff-]+/gi, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const token = new URL(req.url).searchParams.get("token") || "";
-    if (token !== process.env.ADMIN_TOKEN) return fail("unauthorized");
-
-    const row = await first(
+    if (getToken(req.url) !== process.env.ADMIN_TOKEN) return fail("unauthorized");
+    const item = await first(
       `SELECT id, slug, name, price, quantity, active, category, description,
               COALESCE(main_image, image_url) AS main_image,
               sizes, colors, updated_at
-       FROM products WHERE id=? OR slug=?`,
+         FROM products
+        WHERE id=? OR slug=?`,
       params.id, params.id
     );
-    if (!row) return fail("not_found", null, 404);
-    return ok({ item: row });
+    if (!item) return fail("not_found");
+    return ok({ item });
   } catch (e: any) {
     return fail("get_product_failed", String(e));
   }
@@ -51,40 +46,32 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const token = new URL(req.url).searchParams.get("token") || "";
-    if (token !== process.env.ADMIN_TOKEN) return fail("unauthorized");
+    if (getToken(req.url) !== process.env.ADMIN_TOKEN) return fail("unauthorized");
 
-    const body = await req.json();
-
-    const name       = (body.name || "").toString().trim();
-    const slug       = normSlug(body.slug || name);
-    const price      = int(body.price, 0);
-    const quantity   = int(body.quantity, 0);
-    const active     = bool(body.active) ? 1 : 0;
-    const category   = (body.category || "").toString().trim();
-    const description= (body.description || "").toString();
-    const sizes      = JSON.stringify(parseArr(body.sizes));
-    const colors     = JSON.stringify(parseArr(body.colors));
-    const main_image = (body.main_image || body.image_url || "").toString().trim();
-    const updated_at = new Date().toISOString();
+    const b = await req.json();
+    const name        = String(b.name || "").trim();
+    const slug        = slugify(b.slug || name);
+    const price       = toInt(b.price);
+    const quantity    = toInt(b.quantity, 0);
+    const active      = toBool(b.active) ? 1 : 0;
+    const category    = String(b.category || "").trim();
+    const description = String(b.description || "");
+    const sizes       = JSON.stringify(toArr(b.sizes));
+    const colors      = JSON.stringify(toArr(b.colors));
+    const main_image  = String(b.main_image || b.image_url || "").trim();
+    const updated_at  = new Date().toISOString();
 
     await run(
       `UPDATE products
-         SET slug=?,
-             name=?, price=?, quantity=?, active=?,
-             category=?, description=?,
-             sizes=?, colors=?,
-             main_image=?, updated_at=?
-       WHERE id=?`,
+          SET slug=?, name=?, price=?, quantity=?, active=?,
+              category=?, description=?, sizes=?, colors=?, main_image=?, updated_at=?
+        WHERE id=?`,
       slug, name, price, quantity, active,
-      category, description,
-      sizes, colors,
-      main_image, updated_at,
+      category, description, sizes, colors, main_image, updated_at,
       params.id
     );
-
-    const row = await first(`SELECT * FROM products WHERE id=?`, params.id);
-    return ok({ item: row });
+    const item = await first("SELECT * FROM products WHERE id=?", params.id);
+    return ok({ item });
   } catch (e: any) {
     return fail("update_product_failed", String(e));
   }
@@ -92,10 +79,8 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const token = new URL(req.url).searchParams.get("token") || "";
-    if (token !== process.env.ADMIN_TOKEN) return fail("unauthorized");
-
-    await run(`DELETE FROM products WHERE id=?`, params.id);
+    if (getToken(req.url) !== process.env.ADMIN_TOKEN) return fail("unauthorized");
+    await run("DELETE FROM products WHERE id=?", params.id);
     return ok();
   } catch (e: any) {
     return fail("delete_product_failed", String(e));


### PR DESCRIPTION
## Summary
- accept `token` or `t` in admin product APIs
- ensure product creation uses unique slugs and consistent JSON errors
- simplify admin product form and list to treat sizes/colors as JSON strings

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c6dc202a48328afe64daa3cd31087