### PR TITLE
fix(ci): switch to wrangler pages deploy; remove optional scheduled function

### DIFF
--- a/.github/workflows/cf-next.yml
+++ b/.github/workflows/cf-next.yml
@@ -33,13 +33,8 @@ jobs:
           echo "=== .vercel/output ==="
           find .vercel/output -maxdepth 3 -type f | sort | head -n 200
 
-      - name: Publish to Cloudflare Pages (Production)
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: dh22
-          directory: .vercel/output/static
-          branch: main
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: '3'
+      - name: Deploy to Cloudflare Pages (Production)
+        run: npx wrangler@3 pages deploy ".vercel/output/static" --project-name="dh22" --branch="main"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/functions/_scheduled.ts
+++ b/functions/_scheduled.ts
@@ -1,4 +1,3 @@
-export const onSchedule = async (event: any, env: any, ctx: any) => {
-  // прогреваем кэш sitemap раз в день
-  await fetch('https://dh22.ru/sitemap.xml', { cf: { cacheTtl: 21600, cacheEverything: true } } as any);
+export const onSchedule: PagesFunction = async (event, env, ctx) => {
+  await fetch('https://dh22.ru/sitemap.xml', { cf: { cacheTtl: 21600, cacheEverything: true } });
 };

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": false,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a localized tsconfig for Cloudflare Pages functions
- simplify scheduled function and drop explicit TS coercion
- change GitHub Actions workflow to use `wrangler pages deploy`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ccb6ab0b4832894720830caa9a2ad