### PR TITLE
chore: configure Cloudflare workers types

### DIFF
--- a/functions/_scheduled.ts
+++ b/functions/_scheduled.ts
@@ -1,3 +1,7 @@
-export const onSchedule: PagesFunction = async (event, env, ctx) => {
-  await fetch('https://dh22.ru/sitemap.xml', { cf: { cacheTtl: 21600, cacheEverything: true } });
+import type { PagesFunction } from "@cloudflare/workers-types";
+
+export const onSchedule: PagesFunction = async (_event, _env, _ctx) => {
+  await fetch("https://dh22.ru/sitemap.xml", {
+    cf: { cacheTtl: 21600, cacheEverything: true }
+  });
 };

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -2,10 +2,13 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["@cloudflare/workers-types"],
     "strict": false,
     "skipLibCheck": true
-  }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@cloudflare/next-on-pages": "1.13.6",
+        "@cloudflare/workers-types": "^4.20240815.0",
         "@types/react": "19.1.9",
         "autoprefixer": "10.4.19",
         "postcss": "8.4.38",
@@ -182,6 +183,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250813.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250813.0.tgz",
+      "integrity": "sha512-RFFjomDndGR+p7ug1HWDlW21qOJyRZbmI99dUtuR9tmwJbSZhUUnSFmzok9lBYVfkMMrO1O5vmB+IlgiecgLEA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react": "19.1.9",
     "autoprefixer": "10.4.19",
     "postcss": "8.4.38",
-    "tailwindcss": "3.4.7"
+    "tailwindcss": "3.4.7",
+    "@cloudflare/workers-types": "^4.20240815.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
   ],
   "exclude": [
     "node_modules",
-    ".next"
+    ".next",
+    "functions"
   ]
 }


### PR DESCRIPTION
## Summary
- add Cloudflare Workers types for Pages functions
- adjust TypeScript configs for Cloudflare and exclude worker code from Next build
- import worker types in scheduled function

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ccef2d31c8328a6219846b34ada74