### PR TITLE
fix: wrap image loader to avoid function prop

### DIFF
--- a/src/app/accessories/page.tsx
+++ b/src/app/accessories/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import { cfLoader } from '@/app/lib/cfImage';
+import CfImage from '@/app/components/CfImage';
 import { all } from '../lib/db';
 import { rub } from '../lib/money';
 
@@ -36,7 +35,7 @@ export default async function Accessories() {
               : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
-                <Image loader={cfLoader} src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
+                <CfImage src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
               <div className="text-sm">{p.name}</div>
               <div className="text-sm opacity-80">{rub(p.price)}</div>
             </Link>

--- a/src/app/components/CfImage.tsx
+++ b/src/app/components/CfImage.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import Image, { type ImageProps } from "next/image";
+import { cfLoader } from "@/app/lib/cfImageClient";
+
+export default function CfImage(props: ImageProps) {
+  return <Image {...props} loader={cfLoader} />;
+}
+

--- a/src/app/new/page.jsx
+++ b/src/app/new/page.jsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import { cfLoader } from '@/app/lib/cfImage';
+import CfImage from '@/app/components/CfImage';
 import { all } from '../lib/db';
 import { rub } from '../lib/money';
 export const runtime = 'edge';
@@ -21,7 +20,7 @@ export default async function NewArrivals() {
               : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
-                <Image loader={cfLoader} src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
+                <CfImage src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
               <div className="text-sm">{p.name}</div>
               <div className="text-sm opacity-80">{rub(p.price)}</div>
             </Link>

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import { cfLoader } from '@/app/lib/cfImage';
+import CfImage from '@/app/components/CfImage';
 import { all } from './lib/db';
 import { rub } from './lib/money';
 export const runtime = 'edge';
@@ -24,7 +23,7 @@ export default async function Home() {
               : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
-                <Image loader={cfLoader} src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
+                <CfImage src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
               <div className="text-sm">{p.name}</div>
               <div className="text-sm opacity-80">{rub(p.price)}</div>
             </Link>

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -1,5 +1,4 @@
-import Image from "next/image";
-import { cfLoader } from "@/app/lib/cfImage";
+import CfImage from "@/app/components/CfImage";
 import { first } from "@/app/lib/db";
 import ProductClient from "./ProductClient";
 
@@ -21,8 +20,7 @@ export default async function ProductPage({ params }: { params:{slug:string} }) 
   return (
     <div className="container mx-auto px-4 py-10 grid md:grid-cols-2 gap-8">
       <div>
-        <Image
-          loader={cfLoader}
+        <CfImage
           src={product.image || "/placeholder.png"}
           alt={product.name}
           width={900}

--- a/src/app/womens/page.tsx
+++ b/src/app/womens/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import { cfLoader } from '@/app/lib/cfImage';
+import CfImage from '@/app/components/CfImage';
 import { all } from '../lib/db';
 import { rub } from '../lib/money';
 
@@ -36,7 +35,7 @@ export default async function Women() {
               : "/placeholder.png";
           return (
             <Link key={p.slug} href={`/product/${p.slug}`} className="card">
-                <Image loader={cfLoader} src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
+                <CfImage src={img} alt={p.name} width={300} height={400} sizes="(max-width:768px) 50vw, 25vw" className="w-full h-auto object-cover border" />
               <div className="text-sm">{p.name}</div>
               <div className="text-sm opacity-80">{rub(p.price)}</div>
             </Link>


### PR DESCRIPTION
## Summary
- add client-side `CfImage` wrapper for Next/Image using custom loader
- replace direct `Image` usage with `CfImage` to prevent passing loader functions from server components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8abba82c832884c85b2d37cdf264