### PR TITLE
feat: support DH22_DB binding and add health check

### DIFF
--- a/src/app/api/health/db/route.ts
+++ b/src/app/api/health/db/route.ts
@@ -1,0 +1,10 @@
+export const runtime = 'edge';
+
+import { d1 } from '@/lib/db';
+
+export async function GET() {
+  const row = await d1().prepare('SELECT 1 AS ok').first<{ ok: number }>();
+  return new Response(JSON.stringify({ ok: row?.ok === 1 }), {
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { queryAll } from '@/lib/db';
 import { resolveImageUrl, firstFromJsonArray, formatPriceRubKopecks } from '@/lib/images';
 
 export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 type Product = {
   id: number; slug: string; name: string; price: number; currency: string;

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { queryAll } from '@/lib/db';
 import { resolveImageUrl, firstFromJsonArray, formatPriceRubKopecks } from '@/lib/images';
 
 export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 type Product = {
   id: number; slug: string; name: string; description?: string | null;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,23 @@
 import { getRequestContext } from '@cloudflare/next-on-pages';
 import type { D1Database } from '@cloudflare/workers-types';
-export function d1() { return (getRequestContext().env as any).DB as D1Database; }
+
+export function d1(): D1Database {
+  const ctx = getRequestContext?.();
+  const env = (ctx as any)?.env as { DH22_DB?: D1Database; DB?: D1Database } | undefined;
+
+  const db =
+    env?.DH22_DB ??
+    env?.DB ??
+    (globalThis as any)?.DH22_DB ??
+    (globalThis as any)?.DB;
+
+  if (!db) {
+    console.error('D1 binding "DH22_DB" (или "DB") не найден. Проверь Settings → Functions → D1 bindings.');
+    throw new Error('Missing D1 binding DH22_DB');
+  }
+  return db as D1Database;
+}
+
 export async function queryAll<T>(sql: string, ...params: any[]): Promise<T[]> {
   const stmt = d1().prepare(sql).bind(...params);
   const { results } = await stmt.all<T>();


### PR DESCRIPTION
## Summary
- support DH22_DB binding in db helper and fallback to DB binding
- ensure main and product pages use edge runtime with dynamic rendering
- add edge health check route for D1 database connectivity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689daca3611c8328a81ace11aa15c104