### PR TITLE
feat: add R2 image upload and qty input fix

### DIFF
--- a/src/app/api/images/upload-r2/route.ts
+++ b/src/app/api/images/upload-r2/route.ts
@@ -1,0 +1,23 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import { getRequestContext } from '@cloudflare/next-on-pages';
+import type { R2Bucket } from '@cloudflare/workers-types';
+
+function slug(s: string){ return s.toLowerCase().replace(/[^a-z0-9._-]+/g,'-').replace(/-+/g,'-').replace(/^-|-$/g,'');}
+
+export async function POST(req: Request) {
+  try {
+    const env = getRequestContext().env as unknown as { DH22_IMAGES: R2Bucket };
+    const form = await req.formData();
+    const file = form.get('file') as File | null;
+    if (!file) return NextResponse.json({ error:'file required' }, { status:400 });
+    const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
+    const key = `${Date.now()}-${slug(file.name || 'upload')}.${ext}`;
+    await env.DH22_IMAGES.put(key, file.stream() as any, {
+      httpMetadata: { contentType: file.type || 'image/jpeg' },
+    });
+    return NextResponse.json({ key, url: `/r2/${key}` }); // храним как /r2/<key>
+  } catch (e:any) {
+    return NextResponse.json({ error: String(e?.message||e) }, { status:500 });
+  }
+}

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { queryAll } from '@/lib/db';
 import { resolveImageUrl, firstFromJsonArray, formatPriceRubKopecks } from '@/lib/images';
+import QtyInput from '@/components/QtyInput';
 
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
@@ -58,11 +59,7 @@ export default async function ProductPage({ params }: { params: { slug: string }
             )}
             <div>
               <label className="block text-sm mb-1">Количество</label>
-              <input
-                type="number" name="qty" min={1} step={1} defaultValue={1}
-                className="border px-3 py-2 w-24"
-                onInput={(e:any) => { const v = Math.max(1, parseInt(e.currentTarget.value || '1', 10)); e.currentTarget.value = String(v); }}
-              />
+              <QtyInput name="qty" defaultValue={1}/>
             </div>
             <input type="hidden" name="slug" value={p.slug} />
             <button className="border px-4 py-2" type="submit">В корзину</button>

--- a/src/components/QtyInput.tsx
+++ b/src/components/QtyInput.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useState } from 'react';
+export default function QtyInput({ name='qty', defaultValue=1 }:{name?:string;defaultValue?:number;}){
+  const [qty, setQty] = useState<number>(defaultValue);
+  return (
+    <input type="number" name={name} min={1} step={1} value={qty}
+      onChange={e=>setQty(Math.max(1, Number(e.target.value)||1))}
+      inputMode="numeric" pattern="[0-9]*" className="border px-3 py-2 w-24" />
+  );
+}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,18 +1,25 @@
-export function resolveImageUrl(src?: string, variant = 'public') {
+const R2_BASE = (process.env.NEXT_PUBLIC_R2_PUBLIC_BASE || '').replace(/\/+$/, '');
+
+// /cdn-cgi/image параметры по умолчанию
+const DEFAULT_OPTS = 'width=1200,quality=85';
+
+export function resolveImageUrl(src?: string, opts = DEFAULT_OPTS) {
   if (!src) return '/placeholder.svg';
-  if (src.startsWith('http')) return src;
-  if (src.startsWith('/i/')) {
-    const id = src.split('/').pop()!;
-    const base = process.env.NEXT_PUBLIC_CF_IMAGES_BASE; // напр. https://imagedelivery.net/<HASH>
-    return base ? `${base}/${id}/${variant}` : `/i/${id}`;
+  if (src.startsWith('http')) {
+    return `/cdn-cgi/image/${opts}/${src}`;
   }
-  return src;
+  // поддерживаем хранение вида "/r2/<key>" или просто "<key>"
+  const key = src.replace(/^\/?r2\//, '');
+  if (!R2_BASE) return '/placeholder.svg';
+  return `/cdn-cgi/image/${opts}/${R2_BASE}/${encodeURI(key)}`;
 }
+
 export function firstFromJsonArray(json?: string): string | undefined {
   if (!json) return undefined;
   try { const arr = JSON.parse(json); return Array.isArray(arr) && arr.length ? arr[0] : undefined; } catch { return undefined; }
 }
-export function formatPriceRubKopecks(v?: number, currency = 'RUB') {
-  if (!v && v !== 0) return '';
-  return new Intl.NumberFormat('ru-RU', { style: 'currency', currency }).format(v / 100);
+
+export function formatPriceRubKopecks(v?: number, currency='RUB'){
+  if (v===undefined || v===null) return '';
+  return new Intl.NumberFormat('ru-RU',{ style:'currency', currency }).format(v/100);
 }


### PR DESCRIPTION
## Summary
- add R2 upload API for images
- resolve R2 image URLs and format price
- update admin product form to upload to R2
- use QtyInput component on PDP to avoid zero qty

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689db5ed1a60832880b5155acf9619fa