### PR TITLE
feat: improve image resolver and quantity input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,10 +24,9 @@ export default async function Home() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {products.map(p => {
           const fallback = firstFromJsonArray(p.images ?? undefined);
-          const src = resolveImageUrl(p.main_image ?? fallback);
           return (
             <Link key={p.id} className="card" href={`/product/${p.slug}`}>
-              <img src={src} alt={p.name} width={300} height={400} loading="lazy" className="w-full h-auto object-cover border" />
+              <img src={resolveImageUrl(p.main_image ?? fallback)} alt={p.name} width={300} height={400} loading="lazy" className="w-full h-auto object-cover border" />
               <div className="text-sm">{p.name}</div>
               <div className="text-sm opacity-80">{formatPriceRubKopecks(p.price, p.currency)}</div>
             </Link>

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -40,7 +40,7 @@ export default async function ProductPage({ params }: { params: { slug: string }
             {features.length ? <div>{features.join(' / ')}</div> : null}
           </div>
 
-          <form className="mt-6 space-y-3" action="/cart">
+          <form className="mt-6 space-y-3" action="/cart" method="POST">
             {!!colors.length && (
               <div>
                 <label className="block text-sm mb-1">Цвет</label>

--- a/src/components/QtyInput.tsx
+++ b/src/components/QtyInput.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { useState } from 'react';
 
-export default function QtyInput({ name='qty', defaultValue=1 }:{name?:string; defaultValue?:number;}) {
+export default function QtyInput({ name = 'qty', defaultValue = 1 }:{
+  name?: string; defaultValue?: number;
+}) {
   const [raw, setRaw] = useState(String(defaultValue));
   return (
     <input
@@ -10,12 +12,11 @@ export default function QtyInput({ name='qty', defaultValue=1 }:{name?:string; d
       inputMode="numeric"
       pattern="[0-9]*"
       value={raw}
-      onChange={(e)=>{
-        // оставляем только цифры, допускаем пусто
-        const v = e.target.value.replace(/[^\d]/g,'');
+      onChange={(e) => {
+        const v = e.target.value.replace(/[^\d]/g, ''); // только цифры, пусто разрешено
         setRaw(v);
       }}
-      onBlur={()=>{
+      onBlur={() => {
         const n = Math.max(1, parseInt(raw || '0', 10));
         setRaw(String(n));
       }}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,13 +1,29 @@
-const R2_BASE = (process.env.NEXT_PUBLIC_R2_PUBLIC_BASE || '').replace(/\/+$/,'');
+const R2_BASE = (process.env.NEXT_PUBLIC_R2_PUBLIC_BASE || '').replace(/\/+$/, '');
+const CF_BASE = (process.env.NEXT_PUBLIC_CF_IMAGES_BASE || '').replace(/\/+$/, '');
 const DEFAULT_OPTS = 'width=1200,quality=85';
 
 export function resolveImageUrl(src?: string, opts = DEFAULT_OPTS) {
   if (!src) return '/placeholder.svg';
+
+  // Полные внешние ссылки
   if (src.startsWith('http')) return `/cdn-cgi/image/${opts}/${src}`;
-  // поддерживаем хранение вида "/r2/<key>" или просто "<key>"
-  const key = src.replace(/^\/?r2\//,'');
-  if (!R2_BASE) return '/placeholder.svg';
-  return `/cdn-cgi/image/${opts}/${R2_BASE}/${encodeURI(key)}`;
+
+  // Локальные ассеты сайта
+  if (src.startsWith('/images/') || src.startsWith('/placeholder.svg')) return src;
+
+  // Старые Cloudflare Images: /i/<id>
+  if (src.startsWith('/i/')) {
+    const id = src.replace(/^\/?i\//, '');
+    if (CF_BASE) return `${CF_BASE}/${id}/public`;
+    return '/placeholder.svg';
+  }
+
+  // R2: /r2/<key> или просто <key>
+  const key = src.replace(/^\/?r2\//, '');
+  if (R2_BASE) return `/cdn-cgi/image/${opts}/${R2_BASE}/${encodeURI(key)}`;
+
+  // Фолбэк — вернём как есть
+  return src;
 }
 
 export function firstFromJsonArray(json?: string): string | undefined {
@@ -15,7 +31,7 @@ export function firstFromJsonArray(json?: string): string | undefined {
   try { const arr = JSON.parse(json); return Array.isArray(arr) && arr.length ? arr[0] : undefined; } catch { return undefined; }
 }
 
-export function formatPriceRubKopecks(v?: number, currency='RUB') {
-  if (v===undefined || v===null) return '';
-  return new Intl.NumberFormat('ru-RU',{style:'currency',currency}).format(v/100);
+export function formatPriceRubKopecks(v?: number, currency = 'RUB') {
+  if (v === undefined || v === null) return '';
+  return new Intl.NumberFormat('ru-RU', { style: 'currency', currency }).format(v / 100);
 }


### PR DESCRIPTION
## Summary
- expand image resolver to handle external, local, Cloudflare Images and R2 paths
- resolve product images on home and product pages
- tweak quantity input component and submit product page form via POST

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc2b152948328b4bcca3afa8ceae7