### PR TITLE
feat: normalize product queries

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
-import { getBestsellers, getClothes } from "@/lib/queries";
+import { getBestsellersSafe, getClothesSafe, getLatest } from "@/lib/queries";
 import QuickNav from "@/components/QuickNav";
+
+const fmt = (cents: number) => (cents / 100).toLocaleString("ru-RU") + " ₽";
 
 export const runtime = "edge";
 
@@ -38,7 +40,7 @@ function Bestsellers({ products }: { products: any[] }) {
             </div>
             <div className="mt-4 text-center">
               <div className="text-sm uppercase tracking-wider text-neutral-700">{p.title}</div>
-              <div className="mt-1 text-[15px] font-semibold">{(p.price/100).toLocaleString("ru-RU")} ₽</div>
+              <div className="mt-1 text-[15px] font-semibold">{fmt(p.price_cents)}</div>
               {p.is_sale ? <div className="mt-1 text-[12px] font-bold uppercase text-accent">Sale</div> : null}
               {p.is_soldout ? <div className="mt-1 text-[12px] font-bold uppercase text-accent/80">Sold Out</div> : null}
             </div>
@@ -90,7 +92,7 @@ function ClothesGrid({ items }: { items: any[] }) {
             <Image src={p.cover_url || "/placeholder.svg"} alt={p.title} width={900} height={1200} className="aspect-[3/4] w-full object-cover transition group-hover:scale-[1.02]" />
             <div className="px-4 pb-6 pt-4 text-center">
               <div className="text-sm uppercase tracking-wider text-neutral-700">{p.title}</div>
-              <div className="mt-1 text-[15px] font-semibold">{(p.price/100).toLocaleString("ru-RU")} ₽</div>
+              <div className="mt-1 text-[15px] font-semibold">{fmt(p.price_cents)}</div>
             </div>
           </a>
         ))}
@@ -153,14 +155,20 @@ function Instagram() {
 }
 
 export default async function Page() {
-  const [bestsellers, clothes] = await Promise.all([getBestsellers(), getClothes()]);
+  const [bestsellers, clothes] = await Promise.all([
+    getBestsellersSafe(12),
+    getClothesSafe(12),
+  ]);
+
+  const clothesData = clothes.length ? clothes : await getLatest(12);
+
   return (
     <div className="grid gap-16">
       <Hero />
       <Bestsellers products={bestsellers} />
       <AllItemsBanner />
       <CategorySplit />
-      <ClothesGrid items={clothes} />
+      <ClothesGrid items={clothesData} />
       <NewsletterCTA />
       <BrandBlock />
       <Instagram />

--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -1,0 +1,27 @@
+export type Raw = Record<string, any>;
+
+export function pickTitle(p: Raw) {
+  return p.title ?? p.name ?? p.product_name ?? p.title_ru ?? p.slug ?? "Товар";
+}
+export function pickPrice(p: Raw) {
+  // храним в копейках? поддержим оба варианта
+  if (typeof p.price_cents === "number") return p.price_cents;
+  if (typeof p.price === "number") return p.price; // уже в копейках
+  return 0;
+}
+export function pickCover(p: Raw) {
+  return p.cover_url ?? p.image_url ?? p.image ?? p.cover ?? "/placeholder.svg";
+}
+export function normalize(p: Raw) {
+  return {
+    id: p.id,
+    slug: p.slug ?? String(p.id ?? ""),
+    title: pickTitle(p),
+    price_cents: pickPrice(p),
+    cover_url: pickCover(p),
+    // мягкие флаги (если колонок нет — дефолт)
+    is_sale: p.is_sale ?? 0,
+    is_bestseller: p.is_bestseller ?? 0,
+    tags: p.tags ?? "",
+  };
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,25 +1,45 @@
+import { normalize } from "@/lib/normalize";
 import { query } from "@/lib/d1";
 
-export async function getBestsellers() {
-  return await query(
+export async function getLatest(limit = 12) {
+  // Без жёстких колонок: только то, что точно есть
+  const rows = await query<any>(
     `
-    SELECT p.id, p.slug, p.title, p.price, p.cover_url, p.is_sale, p.is_bestseller
-    FROM products p
-    WHERE p.is_active=1 AND p.is_bestseller=1
-    ORDER BY p.sort DESC, p.updated_at DESC
-    LIMIT 12
+    SELECT * FROM products
+    WHERE is_active = 1
+    ORDER BY COALESCE(updated_at, created_at) DESC
+    LIMIT ${limit}
   `
   );
+  return rows.map(normalize);
 }
 
-export async function getClothes() {
-  return await query(
+export async function getBestsellersSafe(limit = 12) {
+  // Пытаемся через метку в tags; если нет — просто последние
+  const rows = await query<any>(
     `
-    SELECT p.id, p.slug, p.title, p.price, p.cover_url
-    FROM products p
-    WHERE p.is_active=1 AND p.category='clothes'
-    ORDER BY p.sort DESC, p.created_at DESC
-    LIMIT 12
+    SELECT * FROM products
+    WHERE is_active = 1
+    ORDER BY COALESCE(updated_at, created_at) DESC
+    LIMIT 100
   `
   );
+  const norm = rows.map(normalize);
+  const best = norm.filter(p =>
+    String(p.tags).toLowerCase().includes("bestseller")
+    || p.is_bestseller === 1
+  );
+  return (best.length ? best.slice(0, limit) : norm.slice(0, limit));
+}
+
+export async function getClothesSafe(limit = 12) {
+  const rows = await query<any>(
+    `
+    SELECT * FROM products
+    WHERE is_active = 1 AND (category = 'clothes' OR category_slug = 'clothes')
+    ORDER BY COALESCE(updated_at, created_at) DESC
+    LIMIT ${limit}
+  `
+  );
+  return rows.map(normalize);
 }


### PR DESCRIPTION
## Summary
- add product field normalizer
- use SELECT * queries with normalization for product fetches
- load products on homepage with safe queries and unified price formatter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: It seems to hang during build and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689eff6dc108832891730ba8c78f4bbb