### PR TITLE
feat: add admin catalog queries and normalization

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
-import { getBestsellersSafe, getClothesSafe, getLatest } from "@/lib/queries";
+import { getLatest, getClothes } from "@/lib/queries";
 import QuickNav from "@/components/QuickNav";
+import { fmtRub } from "@/lib/normalize";
 
-const fmt = (cents: number) => (cents / 100).toLocaleString("ru-RU") + " ₽";
 
 export const runtime = "edge";
 
@@ -40,7 +40,7 @@ function Bestsellers({ products }: { products: any[] }) {
             </div>
             <div className="mt-4 text-center">
               <div className="text-sm uppercase tracking-wider text-neutral-700">{p.title}</div>
-              <div className="mt-1 text-[15px] font-semibold">{fmt(p.price_cents)}</div>
+              <div className="mt-1 text-[15px] font-semibold">{fmtRub(p.price_cents)}</div>
             </div>
           </a>
         ))}
@@ -90,7 +90,7 @@ function ClothesGrid({ items }: { items: any[] }) {
             <img src={p.cover_url || "/placeholder.svg"} alt={p.title} className="aspect-[3/4] w-full object-cover transition group-hover:scale-[1.02]" />
             <div className="px-4 pb-6 pt-4 text-center">
               <div className="text-sm uppercase tracking-wider text-neutral-700">{p.title}</div>
-              <div className="mt-1 text-[15px] font-semibold">{fmt(p.price_cents)}</div>
+              <div className="mt-1 text-[15px] font-semibold">{fmtRub(p.price_cents)}</div>
             </div>
           </a>
         ))}
@@ -153,17 +153,17 @@ function Instagram() {
 }
 
 export default async function Page() {
-  const [bestsellers, clothesRaw] = await Promise.all([
-    getBestsellersSafe(12),
-    getClothesSafe(12),
+  const [latest, clothesRaw] = await Promise.all([
+    getLatest(12),
+    getClothes(12),
   ]);
 
-  const clothes = clothesRaw.length ? clothesRaw : await getLatest(12);
+  const clothes = clothesRaw.length ? clothesRaw : latest;
 
   return (
     <div className="grid gap-16">
       <Hero />
-      <Bestsellers products={bestsellers} />
+      <Bestsellers products={latest} />
       <AllItemsBanner />
       <CategorySplit />
       <ClothesGrid items={clothes} />

--- a/src/lib/adminQueries.ts
+++ b/src/lib/adminQueries.ts
@@ -1,0 +1,58 @@
+import { query } from "@/lib/d1";
+import { tableCols } from "@/lib/schema";
+import { normalizeProduct } from "@/lib/normalize";
+
+function orderClause(cols: Set<string>) {
+  const order: string[] = [];
+  if (cols.has("updated_at")) order.push("updated_at DESC");
+  if (cols.has("created_at")) order.push("created_at DESC");
+  if (cols.has("id"))        order.push("id DESC");
+  return order.length ? "ORDER BY " + order.join(", ") : "";
+}
+
+export async function listProductsAdmin(opts: { q?: string; limit?: number; offset?: number } = {}) {
+  const { q = "", limit = 100, offset = 0 } = opts;
+
+  const cols = await tableCols("products");
+  const where: string[] = [];
+  const params: any[] = [];
+
+  // Фильтр активности: У ВАС колонка называется "active"
+  if (cols.has("active")) where.push("active = 1");
+
+  // Поиск по name/slug/description
+  if (q.trim()) {
+    const likeCols = ["name", "slug", "description"].filter(c => cols.has(c));
+    if (likeCols.length) {
+      where.push("(" + likeCols.map(() => "?? LIKE ?").join(" OR ") + ")");
+      // подставим имена колонок и параметры
+      const arr: any[] = [];
+      likeCols.forEach(c => { arr.push(c); arr.push(`%${q}%`); });
+      // позже соберём SQL через безопасную замену имен
+      // для простоты — сформируем строку вручную:
+      const clause = "(" + likeCols.map(c => `${c} LIKE ?`).join(" OR ") + ")";
+      where.pop(); where.push(clause);
+      likeCols.forEach(() => params.push(`%${q}%`));
+    }
+  }
+
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const order = orderClause(cols);
+
+  // Подтянем суммарный остаток из product_variants (если есть таблица)
+  const hasVariants = true; // таблица есть
+  const stockExpr = hasVariants
+    ? `(SELECT COALESCE(SUM(v.stock),0) FROM product_variants v WHERE v.product_id = p.id) AS variants_stock`
+    : `0 AS variants_stock`;
+
+  const sql = `
+    SELECT p.*, ${stockExpr}
+    FROM products p
+    ${whereSql}
+    ${order}
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+  const rows = await query<any>(sql, params);
+  return rows.map(normalizeProduct);
+}
+

--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -1,27 +1,48 @@
 export type Raw = Record<string, any>;
 
-export function pickTitle(p: Raw) {
-  return p.title ?? p.name ?? p.product_name ?? p.title_ru ?? p.slug ?? "Товар";
+function firstFromJsonArray(s: any): string | null {
+  try {
+    const arr = typeof s === "string" ? JSON.parse(s) : Array.isArray(s) ? s : [];
+    return Array.isArray(arr) && arr.length ? String(arr[0]) : null;
+  } catch {
+    return null;
+  }
 }
-export function pickPrice(p: Raw) {
-  // храним в копейках? поддержим оба варианта
-  if (typeof p.price_cents === "number") return p.price_cents;
-  if (typeof p.price === "number") return p.price; // уже в копейках
-  return 0;
-}
-export function pickCover(p: Raw) {
-  return p.cover_url ?? p.image_url ?? p.image ?? p.cover ?? "/placeholder.svg";
-}
-export function normalize(p: Raw) {
+
+export function normalizeProduct(p: Raw) {
+  // Титул — из name/slug
+  const title = p.name ?? p.title ?? p.slug ?? "Товар";
+
+  // Цена храним в копейках (у вас price=529000 -> 5 290 ₽)
+  const price_cents = typeof p.price === "number" ? p.price : 0;
+
+  // Картинка — main_image / image_url / первый из images_json
+  const cover =
+    p.main_image ??
+    p.image_url ??
+    firstFromJsonArray(p.images_json) ??
+    "/placeholder.svg";
+
+  // Суммарный остаток: variants.stock -> p.quantity -> p.stock
+  const stock_total = typeof p.variants_stock === "number"
+    ? p.variants_stock
+    : (typeof p.quantity === "number" ? p.quantity
+       : (typeof p.stock === "number" ? p.stock : 0));
+
   return {
     id: p.id,
     slug: p.slug ?? String(p.id ?? ""),
-    title: pickTitle(p),
-    price_cents: pickPrice(p),
-    cover_url: pickCover(p),
-    // мягкие флаги (если колонок нет — дефолт)
-    is_sale: p.is_sale ?? 0,
-    is_bestseller: p.is_bestseller ?? 0,
-    tags: p.tags ?? "",
+    title,
+    price_cents,
+    cover_url: cover,
+    category: p.category ?? null,
+    subcategory: p.subcategory ?? null,
+    active: p.active ?? 1,
+    is_new: p.is_new ?? 0,
+    stock_total,
   };
 }
+
+export const fmtRub = (cents: number) =>
+  (Number(cents || 0) / 100).toLocaleString("ru-RU") + " ₽";
+


### PR DESCRIPTION
## Summary
- normalize products to expose price, images, categories and stock with fmtRub helper
- add D1 schema helpers and server-side admin product list query
- update admin and index pages to use normalized queries and price formatting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f058784248328b0278c4db9b39ed2