### PR TITLE
Add product variants editing and pricing fixes

### DIFF
--- a/src/app/admin/products/[id]/ProductFormClient.tsx
+++ b/src/app/admin/products/[id]/ProductFormClient.tsx
@@ -1,73 +1,332 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { adminFetch } from "@/lib/adminFetch";
-export const runtime = 'edge';
 
-const CATEGORIES = {
-  "Женская одежда": ["Юбки", "Жакеты", "Платья", "Футболки"],
-  "Аксессуары": ["Сумки", "Ремни", "Украшения", "Жакеты"], // примеры; поправьте под себя
+const CATS: Record<string, string[]> = {
+  "Женская одежда": ["Платья","Футболки","Юбки","Жакеты"],
+  "Аксессуары": ["Сумки","Ремни","Украшения"],
 };
 
-export default function ProductFormClient({ product }: { product: any }) {
+type Variant = { id?: number; color?: string; size?: string; stock?: number; sku?: string };
+
+export default function ProductFormClient({ product, variants: initialVariants }: { product: any; variants: Variant[] }) {
   const [saving, setSaving] = useState(false);
 
-  async function onSubmit(e) {
-    e.preventDefault();
-    const form = e.currentTarget;
-    const fd = new FormData(form);
+  const [name, setName] = useState(product?.name ?? "");
+  const [slug, setSlug] = useState(product?.slug ?? "");
+  const [description, setDescription] = useState(product?.description ?? "");
+  const [priceRub, setPriceRub] = useState(() => Number(product?.price ?? 0) / 100);
+  const [currency, setCurrency] = useState(product?.currency ?? "RUB");
+  const [active, setActive] = useState(Boolean(product?.active ?? 1));
+  const [isNew, setIsNew] = useState(Boolean(product?.is_new ?? 0));
+  const [category, setCategory] = useState(product?.category ?? "");
+  const [subcategory, setSubcategory] = useState(product?.subcategory ?? "");
 
-    // если есть таблица вариантов — соберём их в сериализованный вид, который ожидает API
-    // (оставьте как у вас было; главное — отправлять на endpoint с токеном)
+  const [mainImage, setMainImage] = useState(product?.main_image ?? "");
+  const [imageUrl, setImageUrl] = useState(product?.image_url ?? "");
+  const [imagesJson, setImagesJson] = useState(
+    product?.images_json
+      ? typeof product.images_json === "string"
+        ? product.images_json
+        : JSON.stringify(product.images_json)
+      : "[]"
+  );
+  const [sizesJson, setSizesJson] = useState(
+    product?.sizes_json
+      ? typeof product.sizes_json === "string"
+        ? product.sizes_json
+        : JSON.stringify(product.sizes_json)
+      : "[]"
+  );
+  const [colorsJson, setColorsJson] = useState(
+    product?.colors_json
+      ? typeof product.colors_json === "string"
+        ? product.colors_json
+        : JSON.stringify(product.colors_json)
+      : "[]"
+  );
+
+  const [quantity, setQuantity] = useState<number | "">(product?.quantity ?? "");
+  const [variants, setVariants] = useState<Variant[]>(
+    (initialVariants || []).map(v => ({
+      id: v.id,
+      color: v.color ?? "",
+      size: v.size ?? "",
+      stock: Number(v.stock ?? 0),
+      sku: v.sku ?? "",
+    }))
+  );
+
+  const subcats = useMemo(() => CATS[category] ?? [], [category]);
+
+  function addVariant() {
+    setVariants(v => [...v, { color: "", size: "", stock: 0, sku: "" }]);
+  }
+  function removeVariant(idx: number) {
+    setVariants(v => v.filter((_, i) => i !== idx));
+  }
+  function updateVariant(idx: number, patch: Partial<Variant>) {
+    setVariants(v => v.map((row, i) => (i === idx ? { ...row, ...patch } : row)));
+  }
+
+  function safeArray(text: string) {
+    const t = (text || "").trim();
+    if (!t) return "[]";
+    if (t.startsWith("[")) {
+      try {
+        JSON.parse(t);
+        return t;
+      } catch {
+        /* fallthrough */
+      }
+    }
+    const arr = t.split(/[\n,]/).map(s => s.trim()).filter(Boolean);
+    return JSON.stringify(arr);
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
     setSaving(true);
     try {
+      const fd = new FormData();
+      fd.set("name", name);
+      fd.set("slug", slug);
+      fd.set("description", description);
+      fd.set("price", String(Math.round(Number(priceRub || 0) * 100)));
+      fd.set("currency", currency);
+      fd.set("active", active ? "1" : "0");
+      fd.set("is_new", isNew ? "1" : "0");
+      fd.set("category", category);
+      fd.set("subcategory", subcategory);
+      fd.set("main_image", mainImage);
+      fd.set("image_url", imageUrl);
+      fd.set("images_json", safeArray(imagesJson));
+      fd.set("sizes_json", safeArray(sizesJson));
+      fd.set("colors_json", safeArray(colorsJson));
+      if (quantity !== "") fd.set("quantity", String(quantity));
+
+      fd.set(
+        "variants",
+        JSON.stringify(
+          variants.map(v => ({
+            color: v.color ?? "",
+            size: v.size ?? "",
+            stock: Number(v.stock ?? 0),
+            sku: v.sku ?? "",
+          }))
+        )
+      );
+
       const res = await adminFetch(`/api/admin/products/${product.id}`, { method: "POST", body: fd });
-      // ожидаем JSON { ok: true } либо просто 200 без тела
-      let ok = res.ok;
-      try {
-        const json = await res.json();
-        ok = ok && (json.ok ?? json.success ?? true);
-      } catch { /* тело не JSON — трактуем как успех */ }
+      const ok =
+        res.ok &&
+        ((await res.clone().text()).trim() === "" || (await res.json().catch(() => ({ ok: true }))).ok !== false);
       alert(ok ? "Сохранено" : "Не удалось сохранить");
       if (ok) location.reload();
-    } catch (e) {
+    } catch (err) {
       alert("Ошибка сохранения");
     } finally {
       setSaving(false);
     }
   }
 
-  const cat = product.category ?? "";
-  const sub = product.subcategory ?? "";
-
   return (
-    <form onSubmit={onSubmit} className="space-y-6">
-      {/* остальные поля name, slug, price, images ... */}
+    <form onSubmit={onSubmit} className="space-y-8">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="space-y-4">
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Название</div>
+            <input value={name} onChange={e => setName(e.target.value)} className="h-10 w-full rounded border px-3" />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Слаг</div>
+            <input value={slug} onChange={e => setSlug(e.target.value)} className="h-10 w-full rounded border px-3" />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Описание</div>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              className="min-h-[96px] w-full rounded border p-3"
+            />
+          </label>
+          <div className="grid grid-cols-3 gap-3">
+            <label className="col-span-2 block">
+              <div className="mb-1 text-sm font-medium">Цена (₽)</div>
+              <input
+                type="number"
+                step="0.01"
+                value={priceRub}
+                onChange={e => setPriceRub(Number(e.target.value))}
+                className="h-10 w-full rounded border px-3"
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-sm font-medium">Валюта</div>
+              <select value={currency} onChange={e => setCurrency(e.target.value)} className="h-10 w-full rounded border px-3">
+                <option value="RUB">RUB</option>
+              </select>
+            </label>
+          </div>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <label className="block">
-          <div className="mb-1 text-sm font-medium">Категория</div>
-          <select name="category" defaultValue={cat} className="h-10 w-full rounded border px-3">
-            <option value="">—</option>
-            {Object.keys(CATEGORIES).map((c) => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
-        </label>
+          <div className="flex items-center gap-6">
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={active} onChange={e => setActive(e.target.checked)} />
+              <span>Активен</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={isNew} onChange={e => setIsNew(e.target.checked)} />
+              <span>Новинка</span>
+            </label>
+          </div>
+        </div>
 
-        <label className="block">
-          <div className="mb-1 text-sm font-medium">Подкатегория</div>
-          <select name="subcategory" defaultValue={sub} className="h-10 w-full rounded border px-3">
-            <option value="">—</option>
-            {(CATEGORIES[cat] ?? []).map((s) => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </select>
-        </label>
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <label className="block">
+              <div className="mb-1 text-sm font-medium">Категория</div>
+              <select value={category} onChange={e => setCategory(e.target.value)} className="h-10 w-full rounded border px-3">
+                <option value="">—</option>
+                {Object.keys(CATS).map(c => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <div className="mb-1 text-sm font-medium">Подкатегория</div>
+              <select
+                value={subcategory}
+                onChange={e => setSubcategory(e.target.value)}
+                className="h-10 w-full rounded border px-3"
+              >
+                <option value="">—</option>
+                {subcats.map(s => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Главное изображение (URL)</div>
+            <input value={mainImage} onChange={e => setMainImage(e.target.value)} className="h-10 w-full rounded border px-3" />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Альтернативный URL</div>
+            <input value={imageUrl} onChange={e => setImageUrl(e.target.value)} className="h-10 w-full rounded border px-3" />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Галерея (JSON или через запятую/строки)</div>
+            <textarea
+              value={imagesJson}
+              onChange={e => setImagesJson(e.target.value)}
+              className="min-h-[80px] w-full rounded border p-2 monospace"
+            />
+          </label>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <label className="block">
+              <div className="mb-1 text-sm font-medium">Размеры (JSON или список)</div>
+              <textarea
+                value={sizesJson}
+                onChange={e => setSizesJson(e.target.value)}
+                className="min-h-[80px] w-full rounded border p-2 monospace"
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-sm font-medium">Цвета (JSON или список)</div>
+              <textarea
+                value={colorsJson}
+                onChange={e => setColorsJson(e.target.value)}
+                className="min-h-[80px] w-full rounded border p-2 monospace"
+              />
+            </label>
+          </div>
+
+          <label className="block">
+            <div className="mb-1 text-sm font-medium">Количество (legacy, необязательно)</div>
+            <input
+              type="number"
+              value={quantity}
+              onChange={e => setQuantity(e.target.value === "" ? "" : Number(e.target.value))}
+              className="h-10 w-full rounded border px-3"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-3 text-lg font-semibold">Варианты</div>
+        <div className="overflow-x-auto rounded border">
+          <table className="w-full text-sm">
+            <thead className="bg-neutral-50">
+              <tr>
+                <th className="px-3 py-2 text-left">Цвет</th>
+                <th className="px-3 py-2 text-left">Размер</th>
+                <th className="px-3 py-2 text-left">Остаток</th>
+                <th className="px-3 py-2 text-left">SKU</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {variants.map((v, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-2">
+                    <input
+                      value={v.color ?? ""}
+                      onChange={e => updateVariant(i, { color: e.target.value })}
+                      className="h-9 w-full rounded border px-2"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      value={v.size ?? ""}
+                      onChange={e => updateVariant(i, { size: e.target.value })}
+                      className="h-9 w-full rounded border px-2"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      type="number"
+                      value={v.stock ?? 0}
+                      onChange={e => updateVariant(i, { stock: Number(e.target.value) })}
+                      className="h-9 w-full rounded border px-2"
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <input
+                      value={v.sku ?? ""}
+                      onChange={e => updateVariant(i, { sku: e.target.value })}
+                      className="h-9 w-full rounded border px-2"
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => removeVariant(i)}
+                      className="rounded border px-2 py-1"
+                    >
+                      ✕
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <button type="button" onClick={addVariant} className="mt-3 rounded border px-3 py-1">
+          + добавить вариант
+        </button>
       </div>
 
       <button disabled={saving} className="rounded border px-4 py-2">
-        {saving ? "Сохраняю..." : "Сохранить"}
+        {saving ? "Сохраняю…" : "Сохранить"}
       </button>
     </form>
   );
 }
+

--- a/src/app/admin/products/[id]/page.tsx
+++ b/src/app/admin/products/[id]/page.tsx
@@ -1,13 +1,17 @@
-import ProductFormClient from "./ProductFormClient";
 import { getProductById } from "@/lib/adminQueries";
+import ProductFormClient from "./ProductFormClient";
+
 export const runtime = 'edge';
 
 export default async function Page({ params, searchParams }) {
-  const product = await getProductById(Number(params.id));
+  const id = Number(params.id);
+  const data = await getProductById(id);
+  if (!data) return <div className="p-6">Товар не найден</div>;
+
   return (
-    <div>
-      <h1 className="mb-6 text-3xl font-semibold">{product?.name || "Товар"}</h1>
-      <ProductFormClient product={product} />
+    <div className="p-6">
+      <h1 className="mb-6 text-3xl font-semibold">{data.product?.name || "Товар"}</h1>
+      <ProductFormClient product={data.product} variants={data.variants || []} />
     </div>
   );
 }

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -1,52 +1,61 @@
-export const runtime = "edge";
-
 import { NextResponse } from "next/server";
 import { query } from "@/lib/d1";
 
-function getToken(req: Request) {
-  const url = new URL(req.url);
-  return url.searchParams.get("t") || req.headers.get("x-admin-token") || "";
-}
+export const runtime = "edge";
 
-function isAllowed(token: string) {
-  // TODO: сравнить с секретом/таблицей kv; пока простая проверка на непустой
-  return Boolean(token);
+function getToken(req: Request) {
+  const u = new URL(req.url);
+  return u.searchParams.get("t") || req.headers.get("x-admin-token") || "";
 }
+function ok(data: any = { ok: true }) { return NextResponse.json(data); }
+function bad(msg = "unauthorized", code = 401) { return NextResponse.json({ ok: false, error: msg }, { status: code }); }
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
-  const token = getToken(req);
-  if (!isAllowed(token)) return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  const t = getToken(req);
+  if (!t) return bad();
 
+  const id = Number(params.id);
   const form = await req.formData();
-  const method = (form.get("_method") || "").toString().toUpperCase();
 
+  const method = (form.get("_method") || "").toString().toUpperCase();
   if (method === "DELETE") {
-    await query("DELETE FROM products WHERE id = ?", [params.id]);
-    await query("DELETE FROM product_variants WHERE product_id = ?", [params.id]);
-    return NextResponse.json({ ok: true });
+    await query("DELETE FROM products WHERE id=?", [id]);
+    await query("DELETE FROM product_variants WHERE product_id=?", [id]);
+    return ok();
   }
 
-  // UPDATE полей (минимально важные)
-  const name = form.get("name");
-  const slug = form.get("slug");
-  const price = Number(form.get("price") || 0);
-  const category = form.get("category");
-  const subcategory = form.get("subcategory");
-  const main_image = form.get("main_image") || form.get("image_url");
+  const fields = [
+    "name","slug","description","price","currency","active","is_new",
+    "category","subcategory","main_image","image_url",
+    "images_json","sizes_json","colors_json","quantity"
+  ] as const;
 
-  await query(
-    `UPDATE products
-     SET name = COALESCE(?, name),
-         slug = COALESCE(?, slug),
-         price = COALESCE(?, price),
-         category = COALESCE(?, category),
-         subcategory = COALESCE(?, subcategory),
-         main_image = COALESCE(?, main_image),
-         updated_at = CURRENT_TIMESTAMP
-     WHERE id = ?`,
-    [name, slug, price, category, subcategory, main_image, params.id]
-  );
+  const sets: string[] = [];
+  const paramsArr: any[] = [];
+  for (const f of fields) {
+    const val = form.get(f);
+    if (val !== null && val !== undefined && val !== "") {
+      sets.push(`${f} = ?`);
+      paramsArr.push(f.endsWith("_json") ? String(val) : val);
+    }
+  }
+  if (sets.length) {
+    sets.push("updated_at = CURRENT_TIMESTAMP");
+    await query(`UPDATE products SET ${sets.join(", ")} WHERE id = ?`, [...paramsArr, id]);
+  }
 
-  // при необходимости — обновление variants: пройдите по formData и синхронизируйте
-  return NextResponse.json({ ok: true });
+  const variantsRaw = form.get("variants");
+  if (variantsRaw) {
+    let arr: any[] = [];
+    try { arr = JSON.parse(String(variantsRaw)); } catch {}
+    await query("DELETE FROM product_variants WHERE product_id = ?", [id]);
+    for (const v of arr) {
+      await query(
+        "INSERT INTO product_variants (product_id,color,size,stock,sku) VALUES (?,?,?,?,?)",
+        [id, v.color ?? "", v.size ?? "", Number(v.stock ?? 0), v.sku ?? ""]
+      );
+    }
+  }
+
+  return ok();
 }

--- a/src/app/components/ProductCard.tsx
+++ b/src/app/components/ProductCard.tsx
@@ -14,7 +14,7 @@ export default function ProductCard({ product }: { product: Product }) {
       <Image src={src} alt={product.name} width={900} height={1200} className="aspect-[3/4] w-full object-cover transition group-hover:scale-[1.02]" />
       <div className="px-4 pb-6 pt-4 text-center">
         <div className="text-sm uppercase tracking-wider text-neutral-700">{product.name}</div>
-        <div className="mt-1 text-[15px] font-semibold">{rub(product.price)}</div>
+        <div className="mt-1 text-[15px] font-semibold">{rub((product as any).price ?? (product as any).price_cents)}</div>
       </div>
     </Link>
   );

--- a/src/app/product/[slug]/ProductClient.tsx
+++ b/src/app/product/[slug]/ProductClient.tsx
@@ -62,7 +62,7 @@ export default function ProductClient({ product }: { product: Product }) {
   return (
     <div>
       <h1 className="text-3xl font-medium">{product.name}</h1>
-      <div className="text-xl mt-2">{rub(product.price)}</div>
+      <div className="text-xl mt-2">{rub((product as any).price ?? (product as any).price_cents)}</div>
       {product.description && <p className="opacity-80 mt-4">{product.description}</p>}
 
       {filteredColors.length ? (

--- a/src/lib/adminQueries.ts
+++ b/src/lib/adminQueries.ts
@@ -58,6 +58,11 @@ export async function listProductsAdmin(opts: { q?: string; limit?: number; offs
 
 
 export async function getProductById(id: number) {
-  const rows = await query<any>("SELECT * FROM products WHERE id = ?", [id]);
-  return rows[0] || null;
+  const [p] = await query<any>("SELECT * FROM products WHERE id = ?", [id]);
+  if (!p) return null;
+  const variants = await query<any>(
+    "SELECT id, color, size, stock, sku FROM product_variants WHERE product_id = ? ORDER BY id",
+    [id]
+  );
+  return { product: p, variants };
 }


### PR DESCRIPTION
## Summary
- fetch product variants alongside product data for editing
- extend admin product form to manage all fields and variant rows
- implement API update route syncing product and variant records
- fix price display to use either `price` or `price_cents`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f13878f288328b6e803397ad6bcd7