### PR TITLE
feat: ensure draft product mutation is type-safe

### DIFF
--- a/src/app/admin/products/new/page.tsx
+++ b/src/app/admin/products/new/page.tsx
@@ -4,6 +4,6 @@ import { redirect } from "next/navigation";
 export default async function NewProductPage({ searchParams }: { searchParams: any }) {
   const t = searchParams?.t ? String(searchParams.t) : "";
   const id = await createDraftProduct();
-  redirect({ pathname: `/admin/products/${id}`, query: t ? { t } : {} } as any);
+  redirect(`/admin/products/${id}${t ? `?t=${encodeURIComponent(t)}` : ""}`);
 }
 

--- a/src/lib/adminMutations.ts
+++ b/src/lib/adminMutations.ts
@@ -1,37 +1,39 @@
 import { query } from "@/lib/d1";
 import { tableCols } from "@/lib/schema";
 
+type RowId = { id: number };
+
 function slugify(base: string) {
-  return base
-    .toLowerCase()
-    .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9\-а-яё]/g, "")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "") || "product";
+  return (
+    base
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9\-а-яё]/g, "")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "product"
+  );
 }
 
 async function uniqueSlug(base: string) {
-  let slug = slugify(base);
+  let candidate = slugify(base);
   let i = 1;
-  // простая проверка уникальности
-  while (true) {
-    const rows = await query<any>("SELECT id FROM products WHERE slug = ? LIMIT 1", [slug]);
-    if (!rows.length) return slug;
-    slug = `${base}-${++i}`;
+  for (;;) {
+    const rows = await query<RowId>(
+      `SELECT id FROM products WHERE slug = ? LIMIT 1`,
+      [candidate]
+    );
+    if (!rows.length) return candidate;
+    candidate = `${base}-${++i}`;
   }
 }
 
 export async function createDraftProduct() {
   const cols = await tableCols("products");
 
-  const name = "Новый товар";
-  const slug = await uniqueSlug("new-product");
-
-  // Собираем набор реально существующих колонок
   const data: Record<string, any> = {
-    name,
-    slug,
-    price: 0, // копейки
+    name: "Новый товар",
+    slug: await uniqueSlug("new-product"),
+    price: 0,
     currency: "RUB",
     description: "",
     active: 0,
@@ -46,20 +48,30 @@ export async function createDraftProduct() {
     quantity: 0,
   };
 
-  const fields = Object.keys(data).filter(k => cols.has(k));
-  const values = fields.map(f => data[f]);
+  const fields = Object.keys(data).filter((k) => cols.has(k));
+  const values = fields.map((f) => data[f]);
 
-  // D1 поддерживает RETURNING, но оставим фолбэк на last_insert_rowid()
-  let row = await query<any>(
-    `INSERT INTO products (${fields.join(",")}) VALUES (${fields.map(()=>"?").join(",")}) RETURNING id`,
-    values
-  ).catch(async () => {
-    await query<any>(`INSERT INTO products (${fields.join(",")}) VALUES (${fields.map(()=>"?").join(",")})`, values);
-    const [r] = await query<any>("SELECT last_insert_rowid() AS id");
-    return [r];
-  });
+  let rows: RowId[] = [];
+  try {
+    // если D1 поддерживает RETURNING
+    rows = await query<RowId>(
+      `INSERT INTO products (${fields.join(",")}) VALUES (${fields
+        .map(() => "?")
+        .join(",")}) RETURNING id`,
+      values
+    );
+  } catch {
+    // фолбэк для окружений без RETURNING
+    await query(
+      `INSERT INTO products (${fields.join(",")}) VALUES (${fields
+        .map(() => "?")
+        .join(",")})`,
+      values
+    );
+    rows = await query<RowId>(`SELECT last_insert_rowid() AS id`);
+  }
 
-  const id = Array.isArray(row) ? row[0]?.id : row?.id;
+  const id = rows?.[0]?.id;
   if (!id) throw new Error("draft_create_failed");
   return Number(id);
 }


### PR DESCRIPTION
## Summary
- rewrite draft product creation with typed queries and slug uniqueness fallback
- redirect new product creation using a simple string URL

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f1b90bd0c832899496ea7b71c879c