### PR TITLE
Add category slug mapping, bestsellers, and mobile navigation

### DIFF
--- a/src/app/admin/products/[id]/ProductFormClient.tsx
+++ b/src/app/admin/products/[id]/ProductFormClient.tsx
@@ -19,6 +19,7 @@ export default function ProductFormClient({ product, variants: initialVariants }
   const [currency, setCurrency] = useState(product?.currency ?? "RUB");
   const [active, setActive] = useState(Boolean(product?.active ?? 1));
   const [isNew, setIsNew] = useState(Boolean(product?.is_new ?? 0));
+  const [isBestseller, setIsBestseller] = useState(Boolean(product?.is_bestseller ?? 0));
   const [category, setCategory] = useState(
     product?.category === "Женская одежда" ? "Одежда" : (product?.category ?? "")
   );
@@ -98,6 +99,7 @@ export default function ProductFormClient({ product, variants: initialVariants }
       fd.set("currency", currency);
       fd.set("active", active ? "1" : "0");
       fd.set("is_new", isNew ? "1" : "0");
+      fd.set("is_bestseller", isBestseller ? "1" : "0");
       fd.set("category", category);
       fd.set("subcategory", subcategory);
       fd.set("main_image", mainImage);
@@ -179,6 +181,10 @@ export default function ProductFormClient({ product, variants: initialVariants }
             <label className="flex items-center gap-2">
               <input type="checkbox" checked={isNew} onChange={e => setIsNew(e.target.checked)} />
               <span>Новинка</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={isBestseller} onChange={e => setIsBestseller(e.target.checked)} />
+              <span>Бестселлер</span>
             </label>
           </div>
         </div>

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
   }
 
   const fields = [
-    "name","slug","description","price","currency","active","is_new",
+    "name","slug","description","price","currency","active","is_new","is_bestseller",
     "category","subcategory","main_image","image_url",
     "images_json","sizes_json","colors_json","quantity"
   ] as const;

--- a/src/app/catalog/[slug]/page.tsx
+++ b/src/app/catalog/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import ProductCard from "@/app/components/ProductCard";
+import { getByCategorySlug } from "@/lib/queries";
+
+export const runtime = "edge";
+
+export default async function Page({ params }: { params: { slug: string } }) {
+  const items = await getByCategorySlug(params.slug, 120); // slug: clothes | accessories
+
+  const titleMap: Record<string, string> = {
+    clothes: "Одежда",
+    accessories: "Аксессуары",
+    new: "Новинки",
+  };
+  const title = titleMap[params.slug] ?? params.slug;
+
+  const products = items.map((p: any) => ({
+    ...p,
+    name: p.title,
+    price: p.price_cents,
+    main_image: p.cover_url,
+    gallery: [],
+  }));
+
+  return (
+    <div className="page-wrap py-10">
+      <h1 className="mt-2 text-5xl font-black uppercase tracking-tight text-accent">{title}</h1>
+      <div className="mt-6 grid grid-cols-2 gap-6 md:grid-cols-4">
+        {products.map((p: any) => (
+          <ProductCard key={p.slug} product={p} />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/catalog/accessories/page.tsx
+++ b/src/app/catalog/accessories/page.tsx
@@ -1,4 +1,0 @@
-import Page, { generateMetadata, revalidate } from "@/app/accessories/page";
-export const runtime = 'edge';
-export { generateMetadata, revalidate };
-export default Page;

--- a/src/app/catalog/clothes/page.tsx
+++ b/src/app/catalog/clothes/page.tsx
@@ -1,4 +1,0 @@
-import Page, { generateMetadata, revalidate } from "@/app/womens/page";
-export const runtime = 'edge';
-export { generateMetadata, revalidate };
-export default Page;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { getLatest, getClothes } from "@/lib/queries";
+import { getBestsellers, getLatest, getClothes } from "@/lib/queries";
 import QuickNav from "@/components/QuickNav";
 import { fmtRub } from "@/lib/normalize";
 // Если используете доп. секции — оставьте их импорт/рендер позже
@@ -315,13 +315,17 @@ function Instagram() {
 
 /* ================== СТРАНИЦА ================== */
 export default async function Page() {
-  const [latest, clothesRaw] = await Promise.all([getLatest(12), getClothes(12)]);
-  const clothes = clothesRaw.length ? clothesRaw : latest;
+const [bestsellers, latest, clothesRaw] = await Promise.all([
+  getBestsellers(12),
+  getLatest(12),
+  getClothes(12),
+]);
+const clothes = clothesRaw.length ? clothesRaw : latest;
 
   return (
     <div className="mx-auto w-[calc(100%-32px)] max-w-[1400px] space-y-8 py-6 sm:w-[calc(100%-48px)] sm:space-y-12 sm:py-10">
       <Hero />
-      <Bestsellers products={latest} />
+      <Bestsellers products={bestsellers.length ? bestsellers : latest} />
       <AllItemsBanner />
       <CategorySplit />
       <ClothesGrid items={clothes} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,23 +1,27 @@
 import Link from "next/link";
 import Nav from "@/components/layout/Nav";
+import MobileNav from "@/components/layout/MobileNav";
 
 export default function Header() {
   return (
-    <header className="fixed left-1/2 top-4 z-[100] w-[calc(100%-48px)] max-w-[1400px] -translate-x-1/2 rounded-full border border-black/10 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-      <div className="flex items-center justify-between px-4 py-3 text-[13px] uppercase tracking-wide">
-        <Nav />
-        <Link href="/" className="wordmark text-lg font-semibold tracking-widest">
-          DH22
-        </Link>
-        <nav className="flex gap-6">
-          <Link href="/favorites" className="hover:opacity-70">
-            Избранное (0)
+    <>
+      <header className="fixed left-1/2 top-4 z-[100] w-[calc(100%-48px)] max-w-[1400px] -translate-x-1/2 rounded-full border border-black/10 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+        <div className="flex items-center justify-between px-4 py-3 text-[13px] uppercase tracking-wide">
+          <Nav />
+          <Link href="/" className="wordmark text-lg font-semibold tracking-widest">
+            DH22
           </Link>
-          <Link href="/cart" className="hover:opacity-70">
-            Корзина (0)
-          </Link>
-        </nav>
-      </div>
-    </header>
+          <nav className="flex gap-6">
+            <Link href="/favorites" className="hover:opacity-70">
+              Избранное (0)
+            </Link>
+            <Link href="/cart" className="hover:opacity-70">
+              Корзина (0)
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <MobileNav />
+    </>
   );
 }

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+const nav = [
+  { href: "/new",              label: "Новинки" },
+  { href: "/catalog/clothes",  label: "Одежда" },
+  { href: "/catalog/accessories", label: "Аксессуары" },
+  { href: "/info",             label: "Информация" },
+  { href: "/about",            label: "О бренде" },
+  { href: "/gift-card",        label: "Gift Card" },
+];
+
+export default function MobileNav() {
+  const [open, setOpen] = useState(false);
+
+  // Блокируем скролл при открытом меню
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Пилловая шапка — ВСЕГДА видна */}
+      <div className="fixed left-1/2 top-2 z-[60] w-[calc(100%-24px)] -translate-x-1/2 rounded-full bg-white/85 shadow backdrop-blur md:hidden">
+        <div className="flex items-center justify-between px-4 py-3">
+          <button
+            aria-label="Открыть меню"
+            onClick={() => setOpen(true)}
+            className="h-8 w-8 rounded-full ring-accent/20 hover:ring-2"
+          >
+            {/* иконка бургер */}
+            <span className="block h-[2px] w-6 bg-black" />
+            <span className="mt-1 block h-[2px] w-6 bg-black" />
+            <span className="mt-1 block h-[2px] w-6 bg-black" />
+          </button>
+
+          <Link href="/" className="text-xl font-black tracking-wide">DH22</Link>
+
+          <div className="flex items-center gap-4 text-sm">
+            <Link href="/favorites" className="opacity-80">Избранное (0)</Link>
+            <Link href="/cart" className="opacity-80">Корзина (0)</Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Оверлей + сайд-панель */}
+      {open && (
+        <div className="fixed inset-0 z-[70] md:hidden">
+          <button
+            aria-label="Закрыть меню"
+            onClick={() => setOpen(false)}
+            className="absolute inset-0 bg-black/40"
+          />
+          <aside
+            className="absolute left-0 top-0 h-full w-[82%] max-w-[360px] translate-x-0 bg-white p-6 shadow-2xl transition"
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="mb-8 flex items-center justify-between">
+              <div className="text-3xl font-extrabold">DH22</div>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="Закрыть меню"
+                className="h-8 w-8 rounded-full ring-accent/20 hover:ring-2"
+              >
+                ✕
+              </button>
+            </div>
+
+            <nav className="space-y-5">
+              {nav.map((i) => (
+                <Link
+                  key={i.href}
+                  href={i.href}
+                  onClick={() => setOpen(false)}
+                  className="block text-2xl font-semibold tracking-wide"
+                >
+                  {i.label}
+                </Link>
+              ))}
+            </nav>
+
+            <div className="mt-10 space-y-3 text-sm text-neutral-600">
+              <Link href="/privacy">Политика конфиденциальности</Link>
+              <br />
+              <Link href="/terms">Пользовательское соглашение</Link>
+            </div>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/src/lib/adminMutations.ts
+++ b/src/lib/adminMutations.ts
@@ -47,6 +47,7 @@ export async function createDraftProduct() {
     description: "",
     active: 0,
     is_new: 0,
+    is_bestseller: 0,
     category: "",         // ВАЖНО: строка, т.к. у вас NOT NULL
     subcategory: "",
     main_image: "",


### PR DESCRIPTION
## Summary
- map catalog slugs to DB categories and add reusable query
- add bestsellers query and admin toggle
- introduce sticky mobile nav and wire it into header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f63c6964c83289900378640dbe31f