### PR TITLE
feat: send complete cart item data

### DIFF
--- a/src/app/product/[slug]/ProductClient.tsx
+++ b/src/app/product/[slug]/ProductClient.tsx
@@ -42,16 +42,23 @@ export default function ProductClient({ product }: { product: Product }) {
     try {
       setAdding(true);
       // подставьте ваш роут корзины/мутацию
-      await fetch("/api/cart", {
+      const res = await fetch("/api/cart/add", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          productId: product.id,
-          variantId: variant.id,
+          slug: product.slug,
+          price: product.price,
           qty,
+          color,
+          size,
+          variantId: variant.id,
         }),
       });
-      // здесь можно дернуть ваш стор/тост
+      // опционально обработаем ответ сервера
+      if (res.ok) {
+        const data = await res.json();
+        console.log("Cart updated", data);
+      }
     } finally {
       setAdding(false);
     }


### PR DESCRIPTION
## Summary
- use `/api/cart/add` endpoint instead of `/api/cart`
- send full cart item payload including slug, price, quantity, color, size and variant id
- log server response to confirm cart update

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a066917fd48328aa1a623ec24dde7e