### PR TITLE
Add recommended bestsellers to product page

### DIFF
--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -1,11 +1,15 @@
 import { notFound } from "next/navigation";
 import ProductClient from "./ProductClient";
-import { getProductFull } from "@/lib/queries";
+import { getProductFull, getBestsellers } from "@/lib/queries";
+import Recommended from "@/components/product/Recommended";
 
 export const runtime = "edge";
 
 export default async function Page({ params }: { params: { slug: string } }) {
-  const product = await getProductFull(params.slug);
+  const [product, bestsellers] = await Promise.all([
+    getProductFull(params.slug),
+    getBestsellers(4),
+  ]);
   if (!product) notFound();
   if (!product.images?.length) {
     product.images = ["/images/placeholder.png"];
@@ -13,6 +17,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
   return (
     <main className="mx-auto w-[calc(100%-48px)] max-w-[1400px] py-6">
       <ProductClient product={product} />
+      <Recommended items={bestsellers} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- fetch bestsellers along with product data and render recommendations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a06692d1448328bcb6bccaed5b4a5e