### PR TITLE
feat: make product page mobile friendly

### DIFF
--- a/src/app/product/[slug]/ProductClient.tsx
+++ b/src/app/product/[slug]/ProductClient.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Image from "next/image";
+import ProductTabs from "@/components/product/ProductTabs";
 import { fmtRub } from "@/lib/normalize";
 
 type Variant = { id: number; color: string; size: string; stock: number; sku?: string };
@@ -25,7 +26,6 @@ export default function ProductClient({ product }: { product: Product }) {
   const [color, setColor] = React.useState<string>(colors[0] ?? "");
   const [size, setSize]   = React.useState<string>(sizes[0] ?? "");
   const [qty, setQty]     = React.useState<number>(1);
-  const [tab, setTab]     = React.useState<"desc"|"care"|"size">("desc");
   const [adding, setAdding] = React.useState(false);
 
   // текущий вариант
@@ -64,164 +64,134 @@ export default function ProductClient({ product }: { product: Product }) {
     }
   }
 
+  const AddButton = ({ className = "" }) => (
+    <button
+      onClick={handleAdd}
+      disabled={!canAdd || adding}
+      className={`h-11 rounded-xl text-sm font-bold uppercase tracking-wider ${canAdd ? "bg-accent text-white hover:brightness-95" : "bg-neutral-200 text-neutral-500"} ${className}`}
+    >
+      {adding ? "Добавление..." : "Добавить в корзину"}
+    </button>
+  );
+
   return (
-    <div className="grid grid-cols-1 items-start gap-8 md:grid-cols-[1.2fr_1fr]">
-      {/* ---------- ГАЛЕРЕЯ: обычные изображения, БЕЗ внутреннего скролла ---------- */}
-      <div className="space-y-4">
-        {product.images?.filter(Boolean).map((src, i) => (
-          <div key={i} className="overflow-hidden rounded-dh22 bg-neutral-100">
-            <Image
-              src={src}
-              alt={`${product.name} ${i + 1}`}
-              width={1400}
-              height={1750}
-              className="h-auto w-full object-cover"
-              priority={i === 0}
-            />
-          </div>
-        ))}
-      </div>
-
-      {/* ---------- САЙДБАР: прилипает при скролле страницы ---------- */}
-      <aside className="md:sticky md:top-24">
-        <div className="rounded-dh22 border border-neutral-200 bg-white p-5 shadow-sm">
-          <div className="mb-1 text-2xl font-extrabold uppercase tracking-tight">
-            {product.name}
-          </div>
-          <div className="mb-6 text-lg font-semibold text-neutral-900">
-            {fmtRub(product.price)}
-          </div>
-
-          {/* цвет */}
-          {colors.length > 0 && (
-            <div className="mb-4">
-              <div className="mb-2 text-xs font-bold uppercase tracking-wider text-neutral-500">Цвет</div>
-              <div className="flex flex-wrap gap-2">
-                {colors.map(c => {
-                  const selected = c === color;
-                  return (
-                    <button
-                      key={c}
-                      onClick={() => setColor(c)}
-                      aria-pressed={selected}
-                      className={`h-9 rounded-full border px-3 text-sm ${selected ? "border-accent bg-accent text-white" : "border-neutral-300 bg-white"}`}
-                    >
-                      {c}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* размер */}
-          {sizes.length > 0 && (
-            <div className="mb-4">
-              <div className="mb-2 text-xs font-bold uppercase tracking-wider text-neutral-500">Размер</div>
-              <div className="flex flex-wrap gap-2">
-                {sizes.map(s => {
-                  const selected = s === size;
-                  // есть ли вариант с таким размером и текущим цветом
-                  const exists = product.variants.some(v => v.size === s && v.color === color && (v.stock ?? 0) > 0);
-                  return (
-                    <button
-                      key={s}
-                      onClick={() => setSize(s)}
-                      disabled={!exists}
-                      aria-pressed={selected}
-                      className={`h-9 rounded-full border px-3 text-sm ${selected ? "border-accent bg-accent text-white" : "border-neutral-300 bg-white"} ${!exists ? "opacity-40 line-through" : ""}`}
-                      title={!exists ? "Нет в наличии" : ""}
-                    >
-                      {s}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* остаток + кол-во */}
-          <div className="mb-4 flex items-center justify-between">
-            <div className={`text-sm ${inStock ? "text-neutral-600" : "text-red-600"}`}>
-              {inStock ? `В наличии: ${variant?.stock}` : "Нет в наличии"}
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                className="h-8 w-8 rounded-md border text-lg"
-                onClick={() => setQty(q => Math.max(1, q - 1))}
-                aria-label="Уменьшить количество"
-              >−</button>
-              <input
-                type="number"
-                min={1}
-                value={qty}
-                onChange={e => setQty(Math.max(1, Number(e.target.value) || 1))}
-                className="h-8 w-14 rounded-md border text-center"
+    <div className="pb-16 md:pb-0">
+      <div className="grid grid-cols-1 items-start gap-8 md:grid-cols-[1.2fr_1fr]">
+        {/* ---------- ГАЛЕРЕЯ: горизонтальный свайп ---------- */}
+        <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto md:block md:space-y-4 md:overflow-visible md:snap-none md:gap-0">
+          {product.images?.filter(Boolean).map((src, i) => (
+            <div key={i} className="w-full shrink-0 snap-center overflow-hidden rounded-dh22 bg-neutral-100 md:w-auto md:shrink md:snap-none">
+              <Image
+                src={src}
+                alt={`${product.name} ${i + 1}`}
+                width={1400}
+                height={1750}
+                className="h-auto w-full object-cover"
+                priority={i === 0}
               />
-              <button
-                className="h-8 w-8 rounded-md border text-lg"
-                onClick={() => setQty(q => q + 1)}
-                aria-label="Увеличить количество"
-              >+</button>
             </div>
-          </div>
+          ))}
+        </div>
 
-          {/* добавить в корзину */}
-          <button
-            onClick={handleAdd}
-            disabled={!canAdd || adding}
-            className={`mb-5 h-11 w-full rounded-xl text-sm font-bold uppercase tracking-wider ${canAdd ? "bg-accent text-white hover:brightness-95" : "bg-neutral-200 text-neutral-500"}`}
-          >
-            {adding ? "Добавление..." : "Добавить в корзину"}
-          </button>
+        {/* ---------- САЙДБАР: прилипает при скролле страницы ---------- */}
+        <aside className="md:sticky md:top-24">
+          <div className="rounded-dh22 border border-neutral-200 bg-white p-5 shadow-sm">
+            <div className="mb-1 text-2xl font-extrabold uppercase tracking-tight">
+              {product.name}
+            </div>
+            <div className="mb-6 text-lg font-semibold text-neutral-900">
+              {fmtRub(product.price)}
+            </div>
 
-          {/* вкладки */}
-          <div className="flex gap-2">
-            <TabBtn active={tab==="desc"} onClick={()=>setTab("desc")}>Описание</TabBtn>
-            <TabBtn active={tab==="care"} onClick={()=>setTab("care")}>Состав и уход</TabBtn>
-            <TabBtn active={tab==="size"} onClick={()=>setTab("size")}>Размерная сетка</TabBtn>
-          </div>
-
-          <div className="mt-4 text-[15px] leading-7 text-neutral-800">
-            {tab === "desc" && <p>{product.description || "Описание отсутствует."}</p>}
-            {tab === "care" && <p>{product.care || "Информация по уходу и составу будет добавлена."}</p>}
-            {tab === "size" && (
-              <div className="overflow-x-auto">
-                {/* пример простой сетки (можете заменить вашей таблицей) */}
-                <table className="w-full text-sm">
-                  <thead className="text-left text-neutral-500">
-                    <tr>
-                      <th className="py-2 pr-4">Параметр</th>
-                      <th className="py-2 pr-4">XS</th>
-                      <th className="py-2 pr-4">S</th>
-                      <th className="py-2 pr-4">M</th>
-                      <th className="py-2">L</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr><td className="py-2 pr-4">Обхват груди</td><td className="py-2 pr-4">79–84</td><td className="py-2 pr-4">85–89</td><td className="py-2 pr-4">90–94</td><td className="py-2">95–99</td></tr>
-                    <tr><td className="py-2 pr-4">Под грудью</td><td className="py-2 pr-4">65–70</td><td className="py-2 pr-4">70–75</td><td className="py-2 pr-4">75–80</td><td className="py-2">80–85</td></tr>
-                    <tr><td className="py-2 pr-4">Талия</td><td className="py-2 pr-4">57–60</td><td className="py-2 pr-4">60–65</td><td className="py-2 pr-4">66–70</td><td className="py-2">71–75</td></tr>
-                    <tr><td className="py-2 pr-4">Бёдра</td><td className="py-2 pr-4">86–90</td><td className="py-2 pr-4">90–94</td><td className="py-2 pr-4">95–98</td><td className="py-2">99–103</td></tr>
-                  </tbody>
-                </table>
+            {/* цвет */}
+            {colors.length > 0 && (
+              <div className="mb-4">
+                <div className="mb-2 text-xs font-bold uppercase tracking-wider text-neutral-500">Цвет</div>
+                <div className="flex flex-wrap gap-2">
+                  {colors.map(c => {
+                    const selected = c === color;
+                    return (
+                      <button
+                        key={c}
+                        onClick={() => setColor(c)}
+                        aria-pressed={selected}
+                        className={`h-9 rounded-full border px-3 text-sm ${selected ? "border-accent bg-accent text-white" : "border-neutral-300 bg-white"}`}
+                      >
+                        {c}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
             )}
+
+            {/* размер */}
+            {sizes.length > 0 && (
+              <div className="mb-4">
+                <div className="mb-2 text-xs font-bold uppercase tracking-wider text-neutral-500">Размер</div>
+                <div className="flex flex-wrap gap-2">
+                  {sizes.map(s => {
+                    const selected = s === size;
+                    // есть ли вариант с таким размером и текущим цветом
+                    const exists = product.variants.some(v => v.size === s && v.color === color && (v.stock ?? 0) > 0);
+                    return (
+                      <button
+                        key={s}
+                        onClick={() => setSize(s)}
+                        disabled={!exists}
+                        aria-pressed={selected}
+                        className={`h-9 rounded-full border px-3 text-sm ${selected ? "border-accent bg-accent text-white" : "border-neutral-300 bg-white"} ${!exists ? "opacity-40 line-through" : ""}`}
+                        title={!exists ? "Нет в наличии" : ""}
+                      >
+                        {s}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* остаток + кол-во */}
+            <div className="mb-4 flex items-center justify-between">
+              <div className={`text-sm ${inStock ? "text-neutral-600" : "text-red-600"}`}>
+                {inStock ? `В наличии: ${variant?.stock}` : "Нет в наличии"}
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  className="h-8 w-8 rounded-md border text-lg"
+                  onClick={() => setQty(q => Math.max(1, q - 1))}
+                  aria-label="Уменьшить количество"
+                >−</button>
+                <input
+                  type="number"
+                  min={1}
+                  value={qty}
+                  onChange={e => setQty(Math.max(1, Number(e.target.value) || 1))}
+                  className="h-8 w-14 rounded-md border text-center"
+                />
+                <button
+                  className="h-8 w-8 rounded-md border text-lg"
+                  onClick={() => setQty(q => q + 1)}
+                  aria-label="Увеличить количество"
+                >+</button>
+              </div>
+            </div>
+
+            {/* добавить в корзину */}
+            <AddButton className="mb-5 hidden w-full md:block" />
+
+            <ProductTabs
+              description={product.description || "Описание отсутствует."}
+              care={product.care || ""}
+            />
           </div>
-        </div>
-      </aside>
+        </aside>
+      </div>
+
+      {/* липкая кнопка на мобильных */}
+      <div className="fixed bottom-0 left-0 right-0 z-10 bg-white p-4 shadow-[0_-1px_5px_rgba(0,0,0,0.1)] md:hidden">
+        <AddButton className="w-full" />
+      </div>
     </div>
   );
 }
-
-function TabBtn({ active, onClick, children }:{active:boolean; onClick:()=>void; children:React.ReactNode}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`h-9 rounded-full px-3 text-sm font-semibold ${active ? "bg-accent text-white" : "bg-neutral-100 text-neutral-800"}`}
-    >
-      {children}
-    </button>
-  );
-}
-

--- a/src/app/product/[slug]/page.tsx
+++ b/src/app/product/[slug]/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
     product.images = ["/images/placeholder.png"];
   }
   return (
-    <main className="mx-auto w-[calc(100%-48px)] max-w-[1400px] py-6">
+    <main className="mx-auto w-[calc(100%-48px)] max-w-[1400px] pt-6 pb-24 md:pb-6">
       <ProductClient product={product} />
       <Recommended items={bestsellers} />
     </main>


### PR DESCRIPTION
## Summary
- convert product images into a horizontal, swipeable gallery
- reuse `ProductTabs` and add sticky mobile cart button
- pad product page and show recommended items below

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a067de81bc8328b2bbeda0d76e8167