### PR TITLE
Add favorites wishlist with heart, badge and API

### DIFF
--- a/src/app/api/products/by-ids/route.ts
+++ b/src/app/api/products/by-ids/route.ts
@@ -1,0 +1,22 @@
+export const runtime = "edge";
+
+import { NextResponse } from "next/server";
+import { all } from "@/app/lib/db";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const raw = searchParams.get("ids") || "";
+  const ids = raw
+    .split(",")
+    .map(s => Number(s))
+    .filter(n => Number.isFinite(n));
+  if (!ids.length) return NextResponse.json([]);
+
+  const qs = `SELECT id, slug, name as title, main_image as cover_url, price as price_cents
+              FROM products
+              WHERE id IN (${ids.map(() => "?").join(",")})`;
+
+  const rows = await all(qs, ...ids);
+  return NextResponse.json(rows ?? []);
+}
+

--- a/src/app/components/ProductCard.tsx
+++ b/src/app/components/ProductCard.tsx
@@ -4,13 +4,15 @@ import Image from "next/image";
 import { r2Url } from "@/lib/r2";
 import { rub } from "@/app/lib/money";
 import type { Product } from "@/types/product";
+import FavHeart from "@/components/favorites/FavHeart";
 
 export default function ProductCard({ product }: { product: Product }) {
   const images: string[] = Array.isArray(product.gallery) ? product.gallery : [];
   const primary = product.main_image || images[0] || "";
   const src = r2Url(primary) || "/placeholder.svg";
   return (
-    <Link href={`/product/${product.slug}`} className="group overflow-hidden rounded-dh22 bg-neutral-100">
+    <Link href={`/product/${product.slug}`} className="group relative overflow-hidden rounded-dh22 bg-neutral-100">
+      <FavHeart id={product.id} className="absolute right-3 top-3" />
       <Image src={src} alt={product.name} width={900} height={1200} className="aspect-[3/4] w-full object-cover transition group-hover:scale-[1.02]" />
       <div className="px-4 pb-6 pt-4 text-center">
         <div className="text-sm uppercase tracking-wider text-neutral-700">{product.name}</div>

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+  useEffect(() => {
+    // открываем слайдер на текущей странице
+    if (location.hash !== "#favorites") {
+      history.replaceState(null, "", "#favorites");
+    }
+    // если пользователь нажал «назад» — закрываем
+    const onPop = () => {
+      if (location.hash !== "#favorites") router.back();
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, [router]);
+
+  // Делаем компактную «пустую» страницу, чтобы над ней был ваш контент под layout
+  return null;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from "next/script";
 import type { ReactNode } from "react";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import FavoritesSheet from "@/components/favorites/FavoritesSheet";
 
 export const metadata = {
   metadataBase: new URL('https://dh22.ru'),
@@ -38,6 +39,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Header />
         <main className="page-wrap pt-24 pb-24">{children}</main>
         <Footer />
+        {/* Глобальный слайдер избранного */}
+        <FavoritesSheet />
 
         {/* Yandex.Metrika 103743080 */}
         <script

--- a/src/app/product/[slug]/ProductClient.tsx
+++ b/src/app/product/[slug]/ProductClient.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Image from "next/image";
 import ProductTabs from "@/components/product/ProductTabs";
 import { fmtRub } from "@/lib/normalize";
+import FavHeart from "@/components/favorites/FavHeart";
 
 type Variant = { id: number; color: string; size: string; stock: number; sku?: string };
 type Product = {
@@ -101,7 +102,8 @@ export default function ProductClient({ product }: { product: Product }) {
 
         {/* ---------- САЙДБАР: прилипает при скролле страницы ---------- */}
         <aside className="md:sticky md:top-24">
-          <div className="rounded-dh22 border border-neutral-200 bg-white p-5 shadow-sm">
+          <div className="relative rounded-dh22 border border-neutral-200 bg-white p-5 shadow-sm">
+            <FavHeart id={product.id} className="absolute right-4 top-4" />
             <div className="mb-1 text-2xl font-extrabold uppercase tracking-tight">
               {product.name}
             </div>

--- a/src/components/favorites/FavBadge.tsx
+++ b/src/components/favorites/FavBadge.tsx
@@ -1,0 +1,29 @@
+"use client";
+import * as React from "react";
+import { readFavs, subscribeFavs } from "@/lib/favorites";
+import Link from "next/link";
+
+export default function FavBadge({ className = "" }: { className?: string }) {
+  const [count, setCount] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    setCount(readFavs().length);
+    return subscribeFavs(ids => setCount(ids.length));
+  }, []);
+
+  return (
+    <Link
+      href="/#favorites"
+      className={`flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-sm font-medium shadow hover:bg-white ${className}`}
+      aria-label="Открыть избранное"
+    >
+      {/* сердечко */}
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#111" strokeWidth="2"
+           strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/>
+      </svg>
+      <span className="whitespace-nowrap">Избранное ({count})</span>
+    </Link>
+  );
+}
+

--- a/src/components/favorites/FavHeart.tsx
+++ b/src/components/favorites/FavHeart.tsx
@@ -1,0 +1,39 @@
+"use client";
+import * as React from "react";
+import { isFav, toggleFav, subscribeFavs } from "@/lib/favorites";
+
+export default function FavHeart({
+  id,
+  size = 22,
+  className = "",
+}: { id: number; size?: number; className?: string }) {
+  const [active, setActive] = React.useState(false);
+
+  React.useEffect(() => {
+    setActive(isFav(id));
+    return subscribeFavs(() => setActive(isFav(id)));
+  }, [id]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => toggleFav(id)}
+      aria-label={active ? "Убрать из избранного" : "Добавить в избранное"}
+      className={`rounded-full bg-white/90 p-2 shadow transition hover:bg-white ${className}`}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill={active ? "#7B61FF" : "none"}
+        stroke={active ? "#7B61FF" : "#111"}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/>
+      </svg>
+    </button>
+  );
+}
+

--- a/src/components/favorites/FavoritesSheet.tsx
+++ b/src/components/favorites/FavoritesSheet.tsx
@@ -1,0 +1,138 @@
+"use client";
+import * as React from "react";
+import { clearFavs, readFavs, subscribeFavs, toggleFav } from "@/lib/favorites";
+import { fmtRub } from "@/lib/normalize";
+
+type Mini = {
+  id: number;
+  slug: string;
+  title: string;
+  cover_url: string | null;
+  price_cents: number;
+};
+
+async function loadProducts(ids: number[]): Promise<Mini[]> {
+  if (!ids.length) return [];
+  const r = await fetch(`/api/products/by-ids?ids=${ids.join(",")}`, { cache: "no-store" });
+  if (!r.ok) return [];
+  return await r.json();
+}
+
+export default function FavoritesSheet() {
+  const [open, setOpen] = React.useState(false);
+  const [ids, setIds] = React.useState<number[]>([]);
+  const [items, setItems] = React.useState<Mini[]>([]);
+  const [loading, setLoading] = React.useState(false);
+
+  // управление через хэш
+  React.useEffect(() => {
+    const syncHash = () => setOpen(location.hash === "#favorites");
+    syncHash();
+    const onHash = () => syncHash();
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+
+  // следим за изменениями списка
+  React.useEffect(() => {
+    setIds(readFavs());
+    return subscribeFavs(setIds);
+  }, []);
+
+  // загрузка карточек
+  React.useEffect(() => {
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      const data = await loadProducts(ids);
+      if (alive) {
+        // сохраняем порядок, как в ids
+        const index = new Map(data.map(d => [d.id, d]));
+        setItems(ids.map(id => index.get(id)).filter(Boolean) as Mini[]);
+        setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [ids]);
+
+  const close = () => {
+    if (location.hash === "#favorites") history.replaceState(null, "", location.pathname + location.search);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {/* затемнение */}
+      <div
+        className={`fixed inset-0 z-[70] bg-black/30 transition-opacity ${open ? "opacity-100" : "pointer-events-none opacity-0"}`}
+        onClick={close}
+        aria-hidden={!open}
+      />
+      {/* панель */}
+      <aside
+        className={`fixed right-0 top-0 z-[80] h-full w-full max-w-[520px] transform bg-white shadow-xl transition-transform
+                    ${open ? "translate-x-0" : "translate-x-full"}`}
+        role="dialog"
+        aria-label="Избранное"
+      >
+        <div className="flex items-center justify-between border-b px-5 py-4">
+          <h3 className="text-xl font-extrabold uppercase tracking-wide">Вишлист</h3>
+          <button onClick={close} aria-label="Закрыть" className="rounded-full p-2 hover:bg-neutral-100">
+            <svg width="22" height="22" viewBox="0 0 24 24" stroke="#111" strokeWidth="2" fill="none">
+              <path d="M18 6 6 18M6 6l12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex h-[calc(100%-116px)] flex-col">
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {loading && <div className="py-10 text-center text-sm text-neutral-500">Загружаем…</div>}
+            {!loading && items.length === 0 && (
+              <div className="py-10 text-center text-sm text-neutral-500">В избранном пока пусто</div>
+            )}
+            <ul className="space-y-4">
+              {items.map(p => (
+                <li key={p.id} className="flex gap-4 rounded-2xl border p-3">
+                  <a href={`/product/${p.slug}`} className="block w-24 shrink-0 overflow-hidden rounded-xl bg-neutral-100">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={p.cover_url ?? "/placeholder.svg"} alt={p.title} className="h-24 w-24 object-cover" />
+                  </a>
+                  <div className="min-w-0 flex-1">
+                    <a href={`/product/${p.slug}`} className="line-clamp-2 font-medium hover:underline">
+                      {p.title}
+                    </a>
+                    <div className="mt-1 text-sm text-neutral-500">{fmtRub(p.price_cents)}</div>
+                    <div className="mt-2 flex gap-3">
+                      <a
+                        href={`/product/${p.slug}`}
+                        className="rounded-lg bg-black px-3 py-1.5 text-xs font-bold uppercase tracking-wide text-white"
+                      >
+                        К товару
+                      </a>
+                      <button
+                        onClick={() => toggleFav(p.id)}
+                        className="rounded-lg border px-3 py-1.5 text-xs font-semibold"
+                      >
+                        Удалить
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border-t p-4">
+            <button
+              onClick={clearFavs}
+              className="w-full rounded-xl border px-4 py-3 text-sm font-semibold hover:bg-neutral-50"
+            >
+              Очистить раздел
+            </button>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+}
+

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import Nav from "@/components/layout/Nav";
+import FavBadge from "@/components/favorites/FavBadge";
 
 const navItems = [
   { href: "/new", label: "Новинки" },
@@ -37,9 +38,7 @@ export default function Header() {
               DH22
             </Link>
             <nav className="flex gap-6">
-              <Link href="/favorites" className="hover:opacity-70">
-                Избранное (0)
-              </Link>
+              <FavBadge />
               <Link href="/cart" className="hover:opacity-70">
                 Корзина (0)
               </Link>
@@ -70,7 +69,7 @@ export default function Header() {
             {/* RIGHT: fav + cart icons */}
             <div className="flex items-center gap-2">
               <a
-                href="/favorites"
+                href="/#favorites"
                 aria-label="Избранное"
                 className="relative grid h-10 w-10 place-items-center rounded-full bg-white/90 shadow-sm ring-1 ring-black/5"
               >

--- a/src/lib/favorites.ts
+++ b/src/lib/favorites.ts
@@ -1,0 +1,58 @@
+"use client";
+
+const KEY = "dh22:favs";
+
+export type FavId = number;
+
+type Listener = (ids: FavId[]) => void;
+const listeners = new Set<Listener>();
+
+function notify(ids: FavId[]) {
+  listeners.forEach(l => l(ids));
+}
+
+export function readFavs(): FavId[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as FavId[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeFavs(ids: FavId[]) {
+  const uniq: FavId[] = [];
+  for (const n of ids) if (!uniq.includes(n)) uniq.push(n);
+  localStorage.setItem(KEY, JSON.stringify(uniq));
+  notify(uniq);
+}
+
+export function toggleFav(id: FavId) {
+  const ids = new Set(readFavs());
+  ids.has(id) ? ids.delete(id) : ids.add(id);
+  const arr: FavId[] = [];
+  ids.forEach(v => arr.push(v));
+  writeFavs(arr);
+}
+
+export function isFav(id: FavId) {
+  return readFavs().includes(id);
+}
+
+export function clearFavs() {
+  writeFavs([]);
+}
+
+export function subscribeFavs(cb: Listener) {
+  listeners.add(cb);
+  // слушаем изменения между вкладками
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === KEY) cb(readFavs());
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+


### PR DESCRIPTION
## Summary
- implement client-side favorites store
- add heart button, header badge and global favorites sheet
- provide API and route for loading favorites by ids

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06cf2f93c832896d5ff5719deacc8