### PR TITLE
fix cart item matching

### DIFF
--- a/src/app/api/cart/add/route.ts
+++ b/src/app/api/cart/add/route.ts
@@ -14,10 +14,18 @@ export async function POST(req: Request) {
   const body = await req.json() as CartItem;
   const cart = readCart(req.headers.get('cookie') || '');
 
-  const qty = Math.max(1, Number(body.qty||1));
-  const idx = cart.findIndex(i => i.variantId === body.variantId);
+  const qty = Math.max(1, Number(body.qty || 1));
+  const hasVariant = body.variantId !== undefined && body.variantId !== null;
+  const color = body.color ?? null;
+  const size = body.size ?? null;
+  const idx = cart.findIndex(i =>
+    i.slug === body.slug && (
+      hasVariant ? i.variantId === body.variantId : i.variantId == null && i.color === color && i.size === size
+    )
+  );
   if (idx >= 0) cart[idx].qty += qty;
-  else cart.push({ slug: body.slug, price: body.price, qty, color: body.color||null, size: body.size||null, variantId: body.variantId });
+  else
+    cart.push({ slug: body.slug, price: body.price, qty, color, size, variantId: body.variantId ?? null });
 
   const res = NextResponse.json({ ok: true, cart });
   res.headers.set('Set-Cookie', `cart=${encodeURIComponent(JSON.stringify(cart))}; Path=/; Max-Age=2592000; SameSite=Lax`);


### PR DESCRIPTION
## Summary
- ensure cart items are matched by slug and variant-specific keys
- prevent merging of different variants when adding to cart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx -y tsx cartTest.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a0795b446883288cf67084fb35d4b3