### PR TITLE
refactor: remove edge runtime from static pages

### DIFF
--- a/src/app/delivery/page.tsx
+++ b/src/app/delivery/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export const metadata = {

--- a/src/app/oferta/page.tsx
+++ b/src/app/oferta/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export const metadata = {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export const metadata = {

--- a/src/app/returns/page.tsx
+++ b/src/app/returns/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export const metadata = {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,3 @@
-export const runtime = 'edge';
 export const dynamic = 'force-static';
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- remove Edge runtime export from delivery, oferta, privacy, returns, and terms pages
- keep static generation via `dynamic = 'force-static'`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: useSearchParams() should be wrapped in a suspense boundary)


------
https://chatgpt.com/codex/tasks/task_e_68a0cf8522f88328a2317fa1169406e6