### PR TITLE
Keep favorite button visible and add default fill color

### DIFF
--- a/src/components/favorites/FavHeart.tsx
+++ b/src/components/favorites/FavHeart.tsx
@@ -11,15 +11,18 @@ export default function FavHeart({
 
   return (
     <button
-      onClick={(e) => { e.preventDefault(); toggle(item); }}
+      onClick={(e) => {
+        e.preventDefault();
+        toggle(item);
+      }}
       aria-label={isFav ? 'Убрать из избранного' : 'Добавить в избранное'}
-      className={`absolute right-3 top-3 z-10 rounded-full bg-white/90 p-2 shadow transition ${isFav ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} ${className}`}
+      className={`absolute right-3 top-3 z-10 rounded-full bg-white/90 p-2 shadow transition ${className}`}
     >
       <svg
         width={size}
         height={size}
         viewBox="0 0 24 24"
-        className={isFav ? 'fill-[#7B61FF] text-[#7B61FF]' : 'text-neutral-800'}
+        className={isFav ? 'fill-[#7B61FF] text-[#7B61FF]' : 'fill-neutral-800 text-neutral-800'}
       >
         <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.74 0 3.41 1.01 4.22 2.5C11.59 5.01 13.26 4 15 4 17.5 4 19.5 6 19.5 8.5c0 3.78-3.4 6.86-8.05 11.54L12 21.35z"/>
       </svg>


### PR DESCRIPTION
## Summary
- Remove hover-only opacity from favorite heart button so it is always visible
- Show a dark neutral outline for unfavorited hearts while keeping purple when favorited

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0d429ca08832887a31ecb5d215678