### PR TITLE
refactor: simplify mobile header buttons

### DIFF
--- a/src/components/layout/HeaderButtons.tsx
+++ b/src/components/layout/HeaderButtons.tsx
@@ -2,7 +2,6 @@
 
 type ChipProps = {
   href: string;
-  count?: number;
   label: string;
   title: string;
   icon: "heart" | "cart";
@@ -11,13 +10,13 @@ type ChipProps = {
 
 const ACCENT = "#7B61FF";
 
-function Chip({ href, count = 0, label, title, icon, onClick }: ChipProps) {
+function Chip({ href, label, title, icon, onClick }: ChipProps) {
   return (
     <a
       href={href}
       title={title}
       onClick={onClick}
-      className="relative inline-flex items-center gap-2 rounded-full border border-black/10 bg-white px-5 py-3 shadow-sm md:hidden"
+      className="relative inline-flex items-center justify-center rounded-full border border-black/10 bg-white p-3 shadow-sm md:hidden"
       aria-label={label}
     >
       {icon === "heart" ? (
@@ -43,10 +42,6 @@ function Chip({ href, count = 0, label, title, icon, onClick }: ChipProps) {
           />
         </svg>
       )}
-      <span className="text-[15px] font-semibold">{label}</span>
-      <span className="ml-1 inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-black/80 px-2 text-xs font-bold text-white">
-        {count}
-      </span>
     </a>
   );
 }
@@ -62,14 +57,12 @@ export default function HeaderButtons({
     <div className="flex items-center gap-3">
       <Chip
         href="/#favorites"
-        count={favCount}
         label="Избранное"
         title="Избранное"
         icon="heart"
       />
       <Chip
         href="/cart"
-        count={cartCount}
         label="Корзина"
         title="Корзина"
         icon="cart"


### PR DESCRIPTION
## Summary
- remove labels and counters from mobile header buttons to show icon only
- center icons with compact rounded styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a181b896d88328828a2410af0ae15f