### PR TITLE
Remove outdated navigation links

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,10 +6,7 @@ import Nav from "@/components/layout/Nav";
 import HeaderButtons from "@/components/layout/HeaderButtons";
 
 const navItems = [
-  { href: "/new", label: "Новинки" },
-  { href: "/bestsellers", label: "Bestsellers" },
   { href: "/catalog/clothes", label: "Одежда" },
-  { href: "/catalog/accessories", label: "Аксессуары" },
   { href: "/info", label: "Информация" },
   { href: "/about", label: "О бренде" },
 ];

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,10 +1,7 @@
 import Link from "next/link";
 
 const NAV = [
-  { href: "/new", label: "Новинки" },
-  { href: "/bestsellers", label: "Bestsellers" },
   { href: "/catalog/clothes", label: "Одежда" },
-  { href: "/catalog/accessories", label: "Аксессуары" },
   { href: "/info", label: "Информация" },
   { href: "/about", label: "О бренде" },
 ];


### PR DESCRIPTION
## Summary
- drop Новинки, Bestsellers, and Аксессуары links from global navigation
- keep navigation to clothing, info, and about pages only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1839f65dc8328bd6abc407a122ced