### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/src/app/RootLayoutClient.tsx
+++ b/src/app/RootLayoutClient.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import FavoritesSheet from '@/components/overlays/FavoritesSheet';
 import CartSheet from '@/components/overlays/CartSheet';
+import CookieBanner from '@/components/CookieBanner';
 import { useUI } from '@/store/ui';
 
 export default function RootLayoutClient({ children }:{ children:React.ReactNode }) {
@@ -25,6 +26,7 @@ export default function RootLayoutClient({ children }:{ children:React.ReactNode
       {children}
       <FavoritesSheet />
       <CartSheet />
+      <CookieBanner />
     </>
   );
 }

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem('cookie_consent')) setVisible(true);
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('cookie_consent', '1');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 inset-x-4 flex items-center justify-between rounded-xl bg-white p-4 text-sm shadow-md">
+      <span>
+        Мы используем{' '}
+        <Link href="/privacy" className="text-accent underline">
+          cookie
+        </Link>{' '}
+        для улучшения работы сайта.
+      </span>
+      <button
+        onClick={accept}
+        className="ml-4 rounded-xl bg-accent px-4 py-1 text-xs font-bold uppercase tracking-wider text-white"
+      >
+        OK
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CookieBanner component to request cookie consent using localStorage
- render CookieBanner from RootLayoutClient after CartSheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a185aa7adc832881906c3252a3dcb5