### PR TITLE
feat: use store counts in header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,9 +21,6 @@ export default function Header() {
     };
   }, [open]);
 
-  const favCount = typeof window !== "undefined" ? Number(localStorage.getItem("fav_count") || 0) : 0;
-  const cartCount = typeof window !== "undefined" ? Number(localStorage.getItem("cart_count") || 0) : 0;
-
   return (
     <header
       className="sticky z-40 mx-auto w-[calc(100%-48px)] max-w-[1400px]"
@@ -38,7 +35,7 @@ export default function Header() {
             <Link href="/" className="wordmark text-lg font-semibold tracking-widest">
               DH22
             </Link>
-            <HeaderButtons favCount={favCount} cartCount={cartCount} />
+            <HeaderButtons />
           </div>
         </div>
       </div>
@@ -63,7 +60,7 @@ export default function Header() {
             </Link>
 
             {/* RIGHT: fav + cart icons */}
-            <HeaderButtons favCount={favCount} cartCount={cartCount} />
+            <HeaderButtons />
           </div>
         </div>
 

--- a/src/components/layout/HeaderButtons.tsx
+++ b/src/components/layout/HeaderButtons.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useUI } from "@/store/ui";
+import { useFavorites } from "@/store/favorites";
+import { useCart } from "@/store/cart";
 
 type ChipProps = {
   href: string;
@@ -48,13 +50,9 @@ function Chip({ href, label, title, icon, onClick }: ChipProps) {
   );
 }
 
-export default function HeaderButtons({
-  favCount = 0,
-  cartCount = 0,
-}: {
-  favCount?: number;
-  cartCount?: number;
-}) {
+export default function HeaderButtons() {
+  const favCount = useFavorites((s) => s.count());
+  const cartCount = useCart((s) => s.count());
   const { openFavs } = useUI();
   const onFavsClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- read favourite and cart counts from zustand hooks instead of props
- simplify header button usage by removing localStorage count plumbing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1879406e4832889a7b2fe0d8bb1df