### PR TITLE
feat: open cart sheet when cart empty

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,8 +21,8 @@ export default function Header() {
     };
   }, [open]);
 
-  const favCount = typeof window !== "undefined" ? Number(localStorage.getItem("fav_count") || 0) : 0;
-  const cartCount = typeof window !== "undefined" ? Number(localStorage.getItem("cart_count") || 0) : 0;
+  const favCount =
+    typeof window !== "undefined" ? Number(localStorage.getItem("fav_count") || 0) : 0;
 
   return (
     <header
@@ -38,7 +38,7 @@ export default function Header() {
             <Link href="/" className="wordmark text-lg font-semibold tracking-widest">
               DH22
             </Link>
-            <HeaderButtons favCount={favCount} cartCount={cartCount} />
+            <HeaderButtons favCount={favCount} />
           </div>
         </div>
       </div>
@@ -63,7 +63,7 @@ export default function Header() {
             </Link>
 
             {/* RIGHT: fav + cart icons */}
-            <HeaderButtons favCount={favCount} cartCount={cartCount} />
+            <HeaderButtons favCount={favCount} />
           </div>
         </div>
 

--- a/src/components/layout/HeaderButtons.tsx
+++ b/src/components/layout/HeaderButtons.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCart } from "@/store/cart";
 import { useUI } from "@/store/ui";
 
 type ChipProps = {
@@ -50,15 +51,20 @@ function Chip({ href, label, title, icon, onClick }: ChipProps) {
 
 export default function HeaderButtons({
   favCount = 0,
-  cartCount = 0,
 }: {
   favCount?: number;
-  cartCount?: number;
 }) {
-  const { openFavs } = useUI();
+  const cartItemCount = useCart((s) => s.count());
+  const { openFavs, openCart } = useUI();
   const onFavsClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
     e.preventDefault();
     openFavs();
+  };
+  const onCartClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    if (cartItemCount === 0) {
+      e.preventDefault();
+      openCart();
+    }
   };
   return (
     <div className="flex items-center gap-3">
@@ -74,6 +80,7 @@ export default function HeaderButtons({
         label="Корзина"
         title="Корзина"
         icon="cart"
+        onClick={onCartClick}
       />
 
       <a
@@ -89,10 +96,11 @@ export default function HeaderButtons({
       <a
         href="/cart"
         className="hidden md:inline-flex items-center gap-2 rounded-full border border-black/10 bg-white px-5 py-3 shadow-sm"
+        onClick={onCartClick}
       >
         <span className="text-[15px] font-semibold">Корзина</span>
         <span className="ml-1 inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-black/80 px-2 text-xs font-bold text-white">
-          {cartCount}
+          {cartItemCount}
         </span>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- hook HeaderButtons into cart store to open CartSheet when cart is empty
- drop unused cartCount prop from Header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a187a6e1548328bfb0b0fd5995437e